### PR TITLE
Add log message before package gets scanned

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -195,6 +195,7 @@ async def run(
 
     scanned_packages: list[str] = []
     for package_metadata in packages_to_check:
+        log.info("Starting scan of package '%s'", package_metadata.title)
         with Session(engine) as session:
             pypi_package_scan: PyPIPackageScan | None = session.scalars(
                 select(PyPIPackageScan).filter_by(name=package_metadata.title)


### PR DESCRIPTION
Closes #52 
Log the package about to be scanned, so that it's easier to debug