### PR TITLE
Add HTTP timeouts

### DIFF
--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -56,6 +56,7 @@ class _DragonflyConfig(EnvConfig):
     recipient = "security@pypi.org"
     bcc: set[str] = set()
     threshold: int = 5
+    timeout: int = 25
 
 
 DragonflyConfig = _DragonflyConfig()

--- a/src/bot/exts/dragonfly/_api.py
+++ b/src/bot/exts/dragonfly/_api.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import Self
 
 from aiohttp import ClientSession
+import aiohttp
 
 from bot.constants import DragonflyConfig
 
@@ -90,11 +91,13 @@ async def check_package(
     version: str | None = None,
     *,
     http_session: ClientSession,
+    timeout: int = 25,
 ) -> PackageScanResult | None:
     data = dict(package_name=package_name, package_version=version)
     async with http_session.post(
         DragonflyConfig.dragonfly_api_url + "/check/",
         json=data,
+        timeout=aiohttp.ClientTimeout(total=timeout),
     ) as res:
         json = await res.json()
 


### PR DESCRIPTION
Add an HTTP timeout specified in `constants.py` under `DragonflyConfig`. Packages that exceed this timeout will still be added to the database with a "timed out" error message.