### PR TITLE
Remove timeout on audit command paginator

### DIFF
--- a/src/bot/exts/audit.py
+++ b/src/bot/exts/audit.py
@@ -17,7 +17,7 @@ from .dragonfly._api import lookup_package_info
 
 class PaginatorView(ui.View):
     def __init__(self, *, member: discord.Member | discord.User, packages: list[PackageScanResult], per: int = 15):
-        super().__init__(timeout=600)
+        super().__init__(timeout=None)
         pages = math.ceil(len(packages) / per)
         self.member = member
         self.embeds = [


### PR DESCRIPTION
Closes #122 

I think the best solution for now to this issue is to simply bump how long the timeout is (since I believe that's the cause of the interaction failing)

We could send all the embeds at once but we'd hit rate limits pretty fast, which is not viable.