### PR TITLE
Fix report payload to not always override

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -39,13 +39,17 @@ class ConfirmReportModal(discord.ui.Modal):
         self.bot = bot
 
     async def on_submit(self, interaction: discord.Interaction):
+        # discord.py returns empty string "" if not filled out, we want it to be `None`
+        additional_information_override = self.additional_information or None
+        inspector_url_override = self.inspector_url or None
+
         log.info(
             "User %s reported package %s@%s with additional_information '%s' and inspector_url '%s'",
             interaction.user,
             self.package.name,
             self.package.version,
-            self.additional_information.value,
-            self.inspector_url.value,
+            additional_information_override,
+            inspector_url_override,
         )
 
         log_channel = interaction.client.get_channel(DragonflyConfig.logs_channel_id)
@@ -53,8 +57,8 @@ class ConfirmReportModal(discord.ui.Modal):
             await log_channel.send(
                 f"User {interaction.user.mention} "
                 f"reported package `{self.package.name}` "
-                f"with additional_description `{self.additional_information.value}`"
-                f"with inspector_url `{self.inspector_url.value}`"
+                f"with additional_description `{additional_information_override}`"
+                f"with inspector_url `{inspector_url_override}`"
             )
 
         url = f"{DragonflyConfig.api_url}/report"
@@ -62,8 +66,8 @@ class ConfirmReportModal(discord.ui.Modal):
         json = dict(
             name=self.package.name,
             version=self.package.version,
-            inspector_url=self.inspector_url.value,
-            additional_information=self.additional_information.value,
+            inspector_url=inspector_url_override,
+            additional_information=additional_information_override,
         )
         async with self.bot.http_session.post(url=url, json=json, headers=headers) as response:
             if response.status == 200:


### PR DESCRIPTION
The popup modal is intended to be an "override" setting to override what's in the database. The Mainframe API would  use the "override" *if it's not None*. However, `discord.py` returns `""` for `ui.TextInput`s that were not filled out, which is *not* None. This meant that the empty string would *always* override what's in the database when sending the email report, which is undesirable. 

This PR fixes it so that `""` becomes `None`, which is then sent as the HTTP payload.