### PR TITLE
Pin python-lint action to 9.0.0

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
   lint:
     needs: pre-commit
-    uses: darbiadev/.github/.github/workflows/python-lint.yaml@ea97d99e1520c46080c4c9032a69552e491474ac # v13.0.0
+    uses: darbiadev/.github/.github/workflows/python-lint.yaml@6a6eb74ae11149881c29adf5a5f7af23349c8762 # v9.0.0
     with:
       python-version: "3.11"
 


### PR DESCRIPTION
The upgrade from [`v9.0.0...v10.0.0`](https://github.com/darbiadev/.github/compare/v9.0.0...v10.0.0) introduces `mypy` to the linting, which fails CI because up until now we've been adhering to Pyright