### PR TITLE
Change embed behavior via package scan score

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -263,12 +263,16 @@ class ReportView(discord.ui.View):
 
 def _build_package_scan_result_embed(scan_result: PackageScanResult) -> discord.Embed:
     """Build the embed that shows the results of a package scan."""
-    embed = discord.Embed(
-        title=f"Malicious package found: {scan_result.name} @ {scan_result.version}",
-        description=f"```YARA rules matched: {', '.join(scan_result.rules) or 'None'}```",
-        color=0xF70606,
-    )
 
+    condition = scan_result.score >= DragonflyConfig.threshold
+    title, color = 'Malicious', 0xF70606 if condition else 'Benign', 0x4CBB17
+
+    embed = discord.Embed(
+        title=f"{title} package found: {scan_result.name} @ {scan_result.version}",
+        description=f"```YARA rules matched: {', '.join(scan_result.rules) or 'None'}```",
+        color=color,
+    )
+    
     embed.add_field(
         name="\u200b",
         value=f"[Inspector]({scan_result.inspector_url})",
@@ -280,7 +284,7 @@ def _build_package_scan_result_embed(scan_result: PackageScanResult) -> discord.
         value=f"[PyPI](https://pypi.org/project/{scan_result.name}/{scan_result.version})",
         inline=True,
     )
-
+        
     return embed
 
 

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -271,7 +271,7 @@ def _build_package_scan_result_embed(scan_result: PackageScanResult) -> discord.
         description=f"```YARA rules matched: {', '.join(scan_result.rules) or 'None'}```",
         color=color,
     )
-    
+
     embed.add_field(
         name="\u200b",
         value=f"[Inspector]({scan_result.inspector_url})",
@@ -283,7 +283,7 @@ def _build_package_scan_result_embed(scan_result: PackageScanResult) -> discord.
         value=f"[PyPI](https://pypi.org/project/{scan_result.name}/{scan_result.version})",
         inline=True,
     )
-        
+
     return embed
 
 

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -263,9 +263,8 @@ class ReportView(discord.ui.View):
 
 def _build_package_scan_result_embed(scan_result: PackageScanResult) -> discord.Embed:
     """Build the embed that shows the results of a package scan."""
-
     condition = scan_result.score >= DragonflyConfig.threshold
-    title, color = 'Malicious', 0xF70606 if condition else 'Benign', 0x4CBB17
+    title, color = "Malicious", 0xF70606 if condition else "Benign", 0x4CBB17
 
     embed = discord.Embed(
         title=f"{title} package found: {scan_result.name} @ {scan_result.version}",


### PR DESCRIPTION
If the scan's score is above the pre-configured threshold, display a malicious package embed. Otherwise return a different embed to reflect the fact that the package does not seem to be malicious.