### PR TITLE
Back out "ci(sentry-release): pin action to v1"

### DIFF
--- a/.github/workflows/sentry-release.yaml
+++ b/.github/workflows/sentry-release.yaml
@@ -13,8 +13,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Create Sentry release
-        # See https://github.com/getsentry/action-release/issues/258
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@00ed2a6cc2171514e031a0f5b4b3cdc586dc171a  # v3.1.1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}


### PR DESCRIPTION
This backs out commit f4405c57b817933401e3b6c622c45e839acdaec1.
