### PR TITLE
Update Inspector URL formatting in embed field

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -301,9 +301,12 @@ def _build_package_scan_result_embed(scan_result: Package) -> discord.Embed:
         timestamp=scan_result.queued_at,
     )
 
+    # Markdown rendering fails in Discord when an Inspector URL includes spaces.
+    quoted_inspector_url = urllib.parse.quote(scan_result.inspector_url, safe=":/")
+
     embed.add_field(
         name="\u200b",
-        value=f"[Inspector]({scan_result.inspector_url.replace(" ", "%20")})", # Markdown rendering fails in Discord when an Inspector URL includes spaces.
+        value=f"[Inspector]({quoted_inspector_url})", 
         inline=True,
     )
 

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -1,6 +1,7 @@
 """Download the most recent packages from PyPI and use Dragonfly to check them for malware."""
 
 import logging
+import urllib.parse
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from logging import getLogger

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -303,7 +303,7 @@ def _build_package_scan_result_embed(scan_result: Package) -> discord.Embed:
 
     embed.add_field(
         name="\u200b",
-        value=f"[Inspector]({scan_result.inspector_url})",
+        value=f"[Inspector]({scan_result.inspector_url.replace(" ", "%20")})", # Markdown rendering fails in Discord when an Inspector URL includes spaces.
         inline=True,
     )
 


### PR DESCRIPTION
Fix Inspector URL formatting to replace spaces with '%20' for proper Markdown rendering in Discord.