### PR TITLE
Fix bot startup with pydis command tree

### DIFF
--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -28,42 +28,6 @@ class BotInitOptions(TypedDict):
     intents: discord.Intents
 
 
-class CommandTree(discord.app_commands.CommandTree[discord.Client]):
-    """Custom command tree that handles errors raised by commands."""
-
-    def __init__(self: Self, bot: discord.Client) -> None:
-        super().__init__(bot)
-
-    async def on_error(
-        self: Self,
-        interaction: discord.Interaction[discord.Client],
-        error: discord.app_commands.AppCommandError,
-    ) -> None:
-        """Override the default error handler to handle custom errors."""
-        if isinstance(error, discord.app_commands.MissingRole):
-            log.warning(
-                "User '%s' attempted to run command '%s', which requires the '%s' role which the user is missing.",
-                interaction.user,
-                interaction.command.name if interaction.command else "None",
-                error.missing_role,
-            )
-
-            await interaction.response.send_message(
-                f"The '{error.missing_role}' role is required to run this command.",
-                ephemeral=True,
-            )
-        elif isinstance(error, discord.app_commands.NoPrivateMessage):
-            log.warning(
-                "User '%s' attempted to run command '%s', which cannot be invoked from DMs",
-                interaction.user,
-                interaction.command,
-            )
-
-            await interaction.response.send_message("This command cannot be used in DMs.", ephemeral=True)
-        else:
-            raise error
-
-
 class Bot(BotBase):  # type: ignore[misc]
     """Bot implementation."""
 
@@ -82,7 +46,6 @@ class Bot(BotBase):  # type: ignore[misc]
         base_init = cast("Callable[..., None]", vars(BotBase)["__init__"])
         base_init(
             self,
-            tree_cls=CommandTree,
             **options,
         )
 

--- a/tests/test_typing_regressions.py
+++ b/tests/test_typing_regressions.py
@@ -6,9 +6,12 @@ import asyncio
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
+import discord
+from aiohttp import ClientSession
 from discord.ext import commands
 
 from bot.bot import Bot
+from bot.dragonfly_services import DragonflyServices
 from bot.exts.core.error_handler import CommandErrorHandler
 from bot.exts.dragonfly import threat_intel_feed
 from bot.utils.messages import get_discord_message
@@ -51,3 +54,25 @@ def test_invalid_command_input_resets_its_cooldown() -> None:
     CommandErrorHandler.revert_cooldown_counter(command, ctx)
 
     command_mock.reset_cooldown.assert_called_once_with(ctx)
+
+
+def test_bot_constructs_with_pydis_command_tree() -> None:
+    """The bot must let pydis-core provide its command-tree implementation."""
+
+    def command_prefix(_bot: Bot, _message: discord.Message) -> list[str]:
+        return ["!"]
+
+    async def construct_bot() -> None:
+        async with ClientSession() as session:
+            dragonfly_services = cast("DragonflyServices", Mock())
+            bot = Bot(
+                dragonfly_services=dragonfly_services,
+                guild_id=1,
+                allowed_roles=[],
+                http_session=session,
+                command_prefix=command_prefix,
+                intents=discord.Intents.none(),
+            )
+            await bot.close()
+
+    asyncio.run(construct_bot())


### PR DESCRIPTION
## Summary

- let `pydis-core` provide its required command-tree implementation
- stop passing a second `tree_cls` through `BotBase`, which crashes with `pydis-core` 11.10.0
- add a real constructor regression test that reproduces the staging startup path

## Incident

The first staging rollout of the upgraded bot entered `CrashLoopBackOff` with:

`TypeError: BotBase.__init__() got multiple values for keyword argument 'tree_cls'`

Staging was immediately rolled back to the prior bot image. Mainframe, loader,
and client remained healthy.

## Validation

- 12 tests passed
- strict Pyright: 0 errors, 0 warnings
- Ruff format and lint passed for `src` and `tests`

The infrastructure rollout PR will be updated to this hotfix merge SHA after
review and merge.
