### PR TITLE
Expose RDAP as a slash command

### DIFF
--- a/src/bot/exts/rdap.py
+++ b/src/bot/exts/rdap.py
@@ -13,7 +13,8 @@ from typing import Any, cast
 from urllib.parse import quote, urlsplit
 
 import aiohttp
-from discord import Embed
+import discord
+from discord import Embed, app_commands
 from discord.ext import commands
 from pydantic import ValidationError
 
@@ -36,6 +37,8 @@ MAX_NAMESERVERS = 3
 MAX_EMBED_TITLE_LENGTH = 256
 MAX_TABLE_LENGTH = 3_900
 MAX_VALUE_LENGTH = 500
+RDAP_REQUEST_ATTEMPTS = 2
+RDAP_REQUEST_TIMEOUT_SECONDS = 15
 RDAP_MEDIA_TYPE = "application/rdap+json"
 RDAP_HEADERS = {
     "Accept": RDAP_MEDIA_TYPE,
@@ -49,20 +52,26 @@ class RDAP(commands.Cog):
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
 
-    @commands.command(name="rdap")
-    async def rdap_command(self, ctx: commands.Context[Bot], *, query: str) -> None:
+    @app_commands.command(
+        name="rdap",
+        description="Look up registration data for a domain, IP address, or ASN",
+    )
+    @app_commands.describe(query="Domain, IP address, or ASN to look up")
+    async def rdap_command(self, interaction: discord.Interaction[Bot], query: str) -> None:
         """
         Perform an RDAP lookup for a domain, IP address, or ASN.
 
         Usage:
-        !rdap example.com
-        !rdap 1.1.1.1
-        !rdap AS13335
+        /rdap query:example.com
+        /rdap query:1.1.1.1
+        /rdap query:AS13335
         """
+        await interaction.response.defer(thinking=True)
+
         try:
             query_type, normalized_query = normalize_query(query)
         except InvalidRDAPQuery as error:
-            await ctx.send(f"❌ {error}")
+            await interaction.followup.send(f"❌ {error}")
             return
 
         try:
@@ -78,11 +87,15 @@ class RDAP(commands.Cog):
             result_data = build_result_data(query_type, data, related_data=related_data)
             table = format_table(result_data)
         except RDAPNotFoundError:
-            await ctx.send(f"❌ No results found for `{normalized_query}`.")
+            await interaction.followup.send(f"❌ No results found for `{normalized_query}`.")
             return
-        except (TimeoutError, aiohttp.ClientError, RDAPResponseError, ValidationError):
+        except TimeoutError:
+            log.exception("RDAP lookup timed out for %s", normalized_query)
+            await interaction.followup.send("❌ The RDAP service timed out. Please try again.")
+            return
+        except (aiohttp.ClientError, RDAPResponseError, ValidationError):
             log.exception("RDAP lookup failed for %s", normalized_query)
-            await ctx.send("❌ The RDAP service returned an invalid response. Please try again later.")
+            await interaction.followup.send("❌ The RDAP service returned an invalid response. Please try again later.")
             return
 
         title = f"RDAP Lookup: {normalized_query}"
@@ -94,7 +107,7 @@ class RDAP(commands.Cog):
             description=table,
             colour=Colours.blue,
         )
-        await ctx.send(embed=embed)
+        await interaction.followup.send(embed=embed)
 
 
 class RDAPResponseError(RuntimeError):
@@ -112,9 +125,24 @@ async def fetch_rdap_data(
     query_type: QueryType,
     query: str,
 ) -> dict[str, Any]:
-    """Fetch and validate an RDAP JSON object."""
+    """Fetch and validate an RDAP JSON object, retrying one transient timeout."""
     url = f"{base_url.rstrip('/')}/{query_type}/{quote(query, safe='')}"
-    async with session.get(url, headers=RDAP_HEADERS) as response:
+    for attempt in range(1, RDAP_REQUEST_ATTEMPTS + 1):
+        try:
+            return await _fetch_rdap_data_once(session, url)
+        except TimeoutError:
+            if attempt == RDAP_REQUEST_ATTEMPTS:
+                raise
+            log.warning("RDAP request timed out; retrying %s", url)
+
+    message = "RDAP request exhausted its attempts"
+    raise AssertionError(message)
+
+
+async def _fetch_rdap_data_once(session: aiohttp.ClientSession, url: str) -> dict[str, Any]:
+    """Perform one bounded RDAP request."""
+    timeout = aiohttp.ClientTimeout(total=RDAP_REQUEST_TIMEOUT_SECONDS)
+    async with session.get(url, headers=RDAP_HEADERS, timeout=timeout) as response:
         if response.status == HTTPStatus.NOT_FOUND:
             raise RDAPNotFoundError
         if response.status != HTTPStatus.OK:
@@ -153,19 +181,25 @@ async def fetch_related_domain_data(
             log.warning("Ignoring unsafe related RDAP URL: %r", related_url)
             continue
 
-        async with session.get(related_url, headers=RDAP_HEADERS, allow_redirects=False) as response:
-            if response.status != HTTPStatus.OK:
-                log.warning("Related RDAP lookup returned HTTP %s", response.status)
-                return None
-            try:
+        try:
+            timeout = aiohttp.ClientTimeout(total=RDAP_REQUEST_TIMEOUT_SECONDS)
+            async with session.get(
+                related_url,
+                headers=RDAP_HEADERS,
+                allow_redirects=False,
+                timeout=timeout,
+            ) as response:
+                if response.status != HTTPStatus.OK:
+                    log.warning("Related RDAP lookup returned HTTP %s", response.status)
+                    return None
                 related_data: object = await response.json()
-            except (aiohttp.ContentTypeError, json.JSONDecodeError, UnicodeDecodeError) as error:
-                message = "Related RDAP server returned invalid JSON"
-                raise RDAPResponseError(message) from error
+        except (TimeoutError, aiohttp.ClientError, json.JSONDecodeError, UnicodeDecodeError):
+            log.warning("Ignoring unavailable related RDAP response from %s", related_url, exc_info=True)
+            return None
 
         if not isinstance(related_data, dict):
-            message = "Related RDAP server did not return a JSON object"
-            raise RDAPResponseError(message)
+            log.warning("Ignoring non-object related RDAP response from %s", related_url)
+            return None
         return cast("dict[str, Any]", related_data)
 
     return None

--- a/src/bot/exts/rdap.py
+++ b/src/bot/exts/rdap.py
@@ -251,7 +251,12 @@ def build_result_data(
     if query_type == "domain":
         models = [RDAPDomain.model_validate(data)]
         if related_data is not None:
-            models.insert(0, RDAPDomain.model_validate(related_data))
+            try:
+                related_model = RDAPDomain.model_validate(related_data)
+            except ValidationError:
+                log.warning("Ignoring schema-invalid related RDAP response", exc_info=True)
+            else:
+                models.insert(0, related_model)
         return _build_domain_result(models)
     if query_type == "ip":
         return _build_ip_result(RDAPIP.model_validate(data))

--- a/tests/test_rdap.py
+++ b/tests/test_rdap.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Coroutine
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
+import discord
 import pytest
-from discord.ext import commands
+from aiohttp import ClientSession
+from discord import app_commands
 
 from bot.bot import Bot
 from bot.exts import rdap
@@ -141,6 +144,47 @@ def test_related_url_safety(url: str, expected: object) -> None:
         assert asyncio.run(rdap.is_safe_related_url(url)) is expected
 
 
+def test_primary_rdap_lookup_retries_one_timeout() -> None:
+    """A transient primary timeout must be retried within the command window."""
+    session = cast("ClientSession", Mock())
+    request = AsyncMock(side_effect=[TimeoutError, {"objectClassName": "domain"}])
+    with patch.object(rdap, "_fetch_rdap_data_once", request):
+        result = asyncio.run(
+            rdap.fetch_rdap_data(
+                session,
+                base_url="https://rdap.example",
+                query_type="domain",
+                query="example.com",
+            )
+        )
+
+    assert result == {"objectClassName": "domain"}
+    assert request.await_count == rdap.RDAP_REQUEST_ATTEMPTS
+
+
+def test_related_rdap_timeout_keeps_primary_result_usable() -> None:
+    """An optional registrar timeout must not discard the registry response."""
+    request_context = AsyncMock()
+    request_context.__aenter__.side_effect = TimeoutError
+    session_mock = Mock()
+    session_mock.get.return_value = request_context
+    session = cast("ClientSession", session_mock)
+    data = {
+        "links": [
+            {
+                "rel": "related",
+                "type": rdap.RDAP_MEDIA_TYPE,
+                "href": "https://rdap.example/domain/example.com",
+            }
+        ]
+    }
+
+    with patch.object(rdap, "is_safe_related_url", AsyncMock(return_value=True)):
+        result = asyncio.run(rdap.fetch_related_domain_data(session, data))
+
+    assert result is None
+
+
 def test_format_table_contains_external_text_safely() -> None:
     """External response text must not break out of the Markdown code block."""
     table = rdap.format_table({"Registrant": "line one\n```injected```"})
@@ -152,9 +196,9 @@ def test_format_table_contains_external_text_safely() -> None:
 def test_rdap_command_handles_request_timeout() -> None:
     """An upstream timeout must produce the RDAP-specific error response."""
     with patch.object(rdap, "fetch_rdap_data", AsyncMock(side_effect=TimeoutError)):
-        ctx_mock = _invoke_rdap_command()
+        interaction_mock = _invoke_rdap_command()
 
-    ctx_mock.send.assert_awaited_once_with("❌ The RDAP service returned an invalid response. Please try again later.")
+    interaction_mock.followup.send.assert_awaited_once_with("❌ The RDAP service timed out. Please try again.")
 
 
 def test_rdap_command_handles_table_overflow() -> None:
@@ -165,9 +209,11 @@ def test_rdap_command_handles_table_overflow() -> None:
         patch.object(rdap, "fetch_related_domain_data", AsyncMock(return_value=None)),
         patch.object(rdap, "build_result_data", return_value=oversized_result),
     ):
-        ctx_mock = _invoke_rdap_command()
+        interaction_mock = _invoke_rdap_command()
 
-    ctx_mock.send.assert_awaited_once_with("❌ The RDAP service returned an invalid response. Please try again later.")
+    interaction_mock.followup.send.assert_awaited_once_with(
+        "❌ The RDAP service returned an invalid response. Please try again later."
+    )
 
 
 def test_rdap_command_bounds_long_domain_title() -> None:
@@ -178,21 +224,36 @@ def test_rdap_command_bounds_long_domain_title() -> None:
         patch.object(rdap, "fetch_related_domain_data", AsyncMock(return_value=None)),
         patch.object(rdap, "build_result_data", return_value={"Domain": query}),
     ):
-        ctx_mock = _invoke_rdap_command(query)
+        interaction_mock = _invoke_rdap_command(query)
 
-    embed = ctx_mock.send.await_args.kwargs["embed"]
+    embed = interaction_mock.followup.send.await_args.kwargs["embed"]
     assert len(embed.title) == rdap.MAX_EMBED_TITLE_LENGTH
     assert embed.title.endswith("…")
+
+
+def test_rdap_is_registered_as_a_slash_command() -> None:
+    """RDAP must be exposed as an application command, not a prefix command."""
+    command = rdap.RDAP.rdap_command
+
+    assert isinstance(command, app_commands.Command)
+    assert command.name == "rdap"
+    assert command.description == "Look up registration data for a domain, IP address, or ASN"
 
 
 def _invoke_rdap_command(query: str = "example.com") -> Mock:
     """Invoke the decorated command callback with typed mocks."""
     bot = cast("Bot", Mock())
-    ctx_mock = Mock()
-    ctx_mock.send = AsyncMock()
-    ctx = cast("commands.Context[Bot]", ctx_mock)
+    interaction_mock = Mock()
+    interaction_mock.response.defer = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
     cog = rdap.RDAP(bot)
-    command = cast("commands.Command[Any, ..., Any]", rdap.RDAP.rdap_command)
+    command = cast("app_commands.Command[Any, ..., Any]", rdap.RDAP.rdap_command)
+    callback = cast(
+        "Callable[[rdap.RDAP, discord.Interaction[Bot], str], Coroutine[Any, Any, None]]",
+        command.callback,
+    )
 
-    asyncio.run(command.callback(cog, ctx, query=query))
-    return ctx_mock
+    asyncio.run(callback(cog, interaction, query))
+    interaction_mock.response.defer.assert_awaited_once_with(thinking=True)
+    return interaction_mock

--- a/tests/test_rdap.py
+++ b/tests/test_rdap.py
@@ -109,6 +109,20 @@ def test_domain_result_combines_registry_and_registrar_responses() -> None:
     assert result["Nameservers"] == "A.IANA-SERVERS.NET"
 
 
+def test_domain_result_ignores_schema_invalid_registrar_response() -> None:
+    """Invalid optional registrar data must not discard a valid registry result."""
+    primary = {
+        "ldhName": "EXAMPLE.COM",
+        "events": [{"eventAction": "registration", "eventDate": "1995-08-14T04:00:00Z"}],
+    }
+    invalid_related = {"entities": "not-a-list"}
+
+    result = rdap.build_result_data("domain", primary, related_data=invalid_related)
+
+    assert result["Domain"] == "EXAMPLE.COM"
+    assert result["Registration"] == "1995-08-14T04:00:00Z"
+
+
 def test_ip_and_asn_models_render_rfc_fields() -> None:
     """IP and ASN aliases must produce useful output rather than None placeholders."""
     ip_model = RDAPIP.model_validate(


### PR DESCRIPTION
## Summary

- replace the RDAP prefix command with `/rdap`
- defer interactions before outbound RDAP requests and send results through follow-ups
- retry one bounded primary timeout and keep valid registry results when optional registrar enrichment is unavailable
- return a specific timeout response instead of appearing to silently fail

## Root cause

The command was implemented with `discord.ext.commands.command`, so it was not registered as an application command. The staging retry for `vipyrsec.com` also showed that the shared 30-second HTTP timeout could expire on the `rdap.org` redirect path without a retry.

## Validation

- `prek run --all-files`
- `uv run --locked pyright`
- `uv run --locked --no-default-groups --group=test pytest` (42 passed)
- `zizmor --pedantic .github/workflows`
- live `rdap.org` → Verisign redirect verification for `vipyrsec.com`
