### PR TITLE
Quell threat feed auth retries

### DIFF
--- a/src/bot/exts/dragonfly/threat_intel_feed.py
+++ b/src/bot/exts/dragonfly/threat_intel_feed.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import re
+from http import HTTPStatus
 from io import BytesIO
 from logging import getLogger
 from typing import cast
@@ -21,6 +22,13 @@ log.setLevel(logging.INFO)
 
 _p = re.compile(r"https://inspector.pypi.io/project/(?P<name>\w+)/(?P<version>[\w.]+)/.*")
 type JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
+REPOSITORY_ACCESS_FAILURES = frozenset(
+    {
+        HTTPStatus.UNAUTHORIZED,
+        HTTPStatus.FORBIDDEN,
+        HTTPStatus.NOT_FOUND,
+    }
+)
 
 
 def build_github_link_from_path(path: str) -> str:
@@ -110,10 +118,27 @@ class ThreatIntelFeed(commands.Cog):
         self.bot = bot
         self.reports_seen: set[str] = set()
 
+    async def fetch_available_zipfile(self) -> ZipFile | None:
+        """Fetch the feed or disable polling for a permanent repository access failure."""
+        try:
+            return await fetch_zipfile(self.bot.http_session)
+        except aiohttp.ClientResponseError as error:
+            if error.status not in REPOSITORY_ACCESS_FAILURES:
+                raise
+            log.warning(
+                "Threat intel feed repository is unavailable (HTTP %s); watcher disabled until restart",
+                error.status,
+            )
+            self.watcher.stop()
+            return None
+
     @tasks.loop(seconds=constants.ThreatIntelFeed.interval)
     async def watcher(self) -> None:
         """Watch the GitHub repository for changes."""
-        zipfile = await fetch_zipfile(self.bot.http_session)
+        zipfile = await self.fetch_available_zipfile()
+        if zipfile is None:
+            return
+
         paths = {path for path in zipfile.namelist() if path.endswith(".json")}
 
         channel = self.bot.get_channel(constants.ThreatIntelFeed.channel_id)
@@ -162,6 +187,8 @@ async def setup(bot: Bot) -> None:
     """Extension setup."""
     cog = ThreatIntelFeed(bot)
     task = cog.watcher
-    if not task.is_running():
+    if not constants.ThreatIntelFeed.access_token:
+        log.warning("Threat intel feed watcher disabled because TIF_ACCESS_TOKEN is not configured")
+    elif not task.is_running():
         task.start()
     await bot.add_cog(cog)

--- a/src/bot/exts/dragonfly/threat_intel_feed.py
+++ b/src/bot/exts/dragonfly/threat_intel_feed.py
@@ -25,7 +25,6 @@ type JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str,
 REPOSITORY_ACCESS_FAILURES = frozenset(
     {
         HTTPStatus.UNAUTHORIZED,
-        HTTPStatus.FORBIDDEN,
         HTTPStatus.NOT_FOUND,
     }
 )

--- a/tests/test_typing_regressions.py
+++ b/tests/test_typing_regressions.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Coroutine
+from http import HTTPStatus
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import discord
-from aiohttp import ClientSession
+import pytest
+from aiohttp import ClientResponseError, ClientSession, RequestInfo
 from discord.ext import commands
 
 from bot.bot import Bot
@@ -37,12 +40,58 @@ def test_threat_intel_setup_starts_an_idle_watcher() -> None:
     bot = cast("Bot", Mock())
     bot.add_cog = AsyncMock()
 
-    with patch.object(threat_intel_feed, "ThreatIntelFeed", return_value=cog):
+    with (
+        patch.object(threat_intel_feed.constants.ThreatIntelFeed, "access_token", "configured"),
+        patch.object(threat_intel_feed, "ThreatIntelFeed", return_value=cog),
+    ):
         asyncio.run(threat_intel_feed.setup(bot))
 
     watcher.is_running.assert_called_once_with()
     watcher.start.assert_called_once_with()
     bot.add_cog.assert_awaited_once_with(cog)
+
+
+def test_threat_intel_setup_stays_idle_without_token() -> None:
+    """A missing token must keep the cog loaded without starting its watcher."""
+    watcher = Mock()
+    cog = Mock(watcher=watcher)
+    bot = cast("Bot", Mock())
+    bot.add_cog = AsyncMock()
+
+    with (
+        patch.object(threat_intel_feed.constants.ThreatIntelFeed, "access_token", ""),
+        patch.object(threat_intel_feed, "ThreatIntelFeed", return_value=cog),
+    ):
+        asyncio.run(threat_intel_feed.setup(bot))
+
+    watcher.is_running.assert_not_called()
+    watcher.start.assert_not_called()
+    bot.add_cog.assert_awaited_once_with(cog)
+
+
+@pytest.mark.parametrize("status", sorted(threat_intel_feed.REPOSITORY_ACCESS_FAILURES))
+def test_threat_intel_watcher_stops_after_repository_access_failure(status: HTTPStatus) -> None:
+    """Permanent GitHub access failures must not enter the task retry loop."""
+    bot = cast("Bot", Mock())
+    cog = threat_intel_feed.ThreatIntelFeed(bot)
+    error = ClientResponseError(
+        cast("RequestInfo", Mock()),
+        (),
+        status=status,
+        message=status.phrase,
+    )
+    callback = cast(
+        "Callable[[threat_intel_feed.ThreatIntelFeed], Coroutine[Any, Any, None]]",
+        threat_intel_feed.ThreatIntelFeed.watcher.coro,
+    )
+
+    with (
+        patch.object(threat_intel_feed, "fetch_zipfile", AsyncMock(side_effect=error)),
+        patch.object(cog.watcher, "stop") as stop,
+    ):
+        asyncio.run(callback(cog))
+
+    stop.assert_called_once_with()
 
 
 def test_invalid_command_input_resets_its_cooldown() -> None:

--- a/tests/test_typing_regressions.py
+++ b/tests/test_typing_regressions.py
@@ -94,6 +94,31 @@ def test_threat_intel_watcher_stops_after_repository_access_failure(status: HTTP
     stop.assert_called_once_with()
 
 
+def test_threat_intel_watcher_retries_forbidden_response() -> None:
+    """A potentially transient GitHub 403 must remain in the task retry loop."""
+    bot = cast("Bot", Mock())
+    cog = threat_intel_feed.ThreatIntelFeed(bot)
+    error = ClientResponseError(
+        cast("RequestInfo", Mock()),
+        (),
+        status=HTTPStatus.FORBIDDEN,
+        message=HTTPStatus.FORBIDDEN.phrase,
+    )
+    callback = cast(
+        "Callable[[threat_intel_feed.ThreatIntelFeed], Coroutine[Any, Any, None]]",
+        threat_intel_feed.ThreatIntelFeed.watcher.coro,
+    )
+
+    with (
+        patch.object(threat_intel_feed, "fetch_zipfile", AsyncMock(side_effect=error)),
+        patch.object(cog.watcher, "stop") as stop,
+        pytest.raises(ClientResponseError, match=HTTPStatus.FORBIDDEN.phrase),
+    ):
+        asyncio.run(callback(cog))
+
+    stop.assert_not_called()
+
+
 def test_invalid_command_input_resets_its_cooldown() -> None:
     """Rejected input must not consume the command cooldown."""
     command_mock = Mock()


### PR DESCRIPTION
## Summary

- keep the Threat Intelligence Feed cog loaded but idle when `TIF_ACCESS_TOKEN` is absent
- stop only the TIF watcher after a permanent GitHub repository access failure
- emit one concise warning instead of repeated task tracebacks
- automatically try again after a normal bot restart once repository access is restored

## Root cause

The TIF watcher allowed GitHub 401 responses to escape into `discord.ext.tasks`. The task framework classified the client error as reconnectable and retried it with backoff, producing recurring tracebacks even though the credential problem could not heal inside the running process.

## Validation

- `prek run --all-files`
- `uv run --locked pyright`
- `uv run --locked --no-default-groups --group=test pytest` (47 passed)
- `zizmor --pedantic .github/workflows`
- regression coverage for missing credentials and GitHub 401/403/404 responses
