### PR TITLE
Add multi-cluster queue status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Vipyr Bot
 
 A Discord bot for Vipyr
+
+## Dragonfly queue status
+
+The `/queue-status` command reports the cached queue snapshot from every configured
+Dragonfly cluster. Configure each cluster with its own Cloudflare Access service
+token:
+
+```text
+DRAGONFLY_QUEUE_CLUSTERS={"production":{"api_url":"https://dragonfly.vipyrsec.com","access_client_id":"...","access_client_secret":"..."},"staging":{"api_url":"https://dragonfly-staging.vipyrsec.com","access_client_id":"...","access_client_secret":"..."}}
+```
+
+If this setting is omitted, the command reports the existing `DRAGONFLY_API_URL` as
+`production`. Queue snapshots are maintained by Mainframe; invoking the command does
+not issue a metrics query against PostgreSQL.

--- a/src/bot/__main__.py
+++ b/src/bot/__main__.py
@@ -33,6 +33,17 @@ async def main() -> None:
             access_client_id=constants.Dragonfly.client_id,
             access_client_secret=constants.Dragonfly.client_secret,
         )
+        dragonfly_queue_services = {"production": dragonfly_services}
+        if constants.DragonflyConfig.queue_clusters:
+            dragonfly_queue_services = {
+                name: DragonflyServices(
+                    session=session,
+                    base_url=cluster.api_url,
+                    access_client_id=cluster.access_client_id,
+                    access_client_secret=cluster.access_client_secret.get_secret_value(),
+                )
+                for name, cluster in constants.DragonflyConfig.queue_clusters.items()
+            }
 
         bot = Bot(
             guild_id=constants.Guild.id,
@@ -41,6 +52,7 @@ async def main() -> None:
             command_prefix=get_prefix,
             intents=intents,
             dragonfly_services=dragonfly_services,
+            dragonfly_queue_services=dragonfly_queue_services,
         )
 
         await bot.start(constants.Bot.token)

--- a/src/bot/bot.py
+++ b/src/bot/bot.py
@@ -34,6 +34,7 @@ class Bot(BotBase):  # type: ignore[misc]
     def __init__(
         self: Self,
         dragonfly_services: DragonflyServices,
+        dragonfly_queue_services: dict[str, DragonflyServices] | None = None,
         **options: Unpack[BotInitOptions],
     ) -> None:
         """Initialise the base bot instance.
@@ -50,6 +51,7 @@ class Bot(BotBase):  # type: ignore[misc]
         )
 
         self.dragonfly_services = dragonfly_services
+        self.dragonfly_queue_services = dragonfly_queue_services or {"production": dragonfly_services}
         self.all_extensions: frozenset[str] | None = None
 
     async def setup_hook(self: Self) -> None:

--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -8,7 +8,7 @@ An `.env` file is used to populate env vars, if present.
 from os import getenv
 from typing import ClassVar
 
-from pydantic import field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -67,6 +67,14 @@ class _Dragonfly(EnvConfig, env_prefix="cf_access_"):
 Dragonfly = _Dragonfly()
 
 
+class DragonflyCluster(BaseModel):
+    """Connection settings for one isolated Dragonfly environment."""
+
+    api_url: str
+    access_client_id: str
+    access_client_secret: SecretStr
+
+
 class _DragonflyConfig(EnvConfig, env_prefix="dragonfly_"):
     """Dragonfly Cog Configuration."""
 
@@ -74,6 +82,7 @@ class _DragonflyConfig(EnvConfig, env_prefix="dragonfly_"):
     logs_channel_id: int = 1121462677131251752
     alerts_role_id: int = 1122647527485878392
     api_url: str = "https://dragonfly.vipyrsec.com"
+    queue_clusters: dict[str, DragonflyCluster] = Field(default_factory=dict)
     interval: int = 60
     threshold: int = 8
     timeout: int = 25

--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -45,6 +45,18 @@ class Package(BaseModel):
         return f"{self.name} {self.version}"
 
 
+class QueueStatus(BaseModel):
+    """Cached queue summary returned by Mainframe."""
+
+    queued: int
+    in_progress: int
+    retryable: int
+    total_backlog: int
+    oldest_queued_at: datetime | None
+    oldest_age_seconds: int | None
+    sampled_at: datetime
+
+
 @dataclass
 class PackageReport:
     """Represents the payload sent to the report endpoint."""
@@ -117,6 +129,11 @@ class DragonflyServices:
 
         data = await self.make_request("GET", "/package", params=params)
         return list(map(Package.model_validate, data))
+
+    async def get_queue_status(self: Self) -> QueueStatus:
+        """Get Mainframe's latest cached queue snapshot."""
+        data = await self.make_request("GET", "/queue-status")
+        return QueueStatus.model_validate(data)
 
     async def report_package(
         self: Self,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -18,6 +18,7 @@ from bot import constants
 from bot.bot import Bot
 from bot.constants import Channels, DragonflyConfig, Roles
 from bot.dragonfly_services import DragonflyServices, Package, PackageReport
+from bot.queue_status import build_queue_status_embed, fetch_cluster_queue_statuses
 from bot.utils.pastebin import PasteFile, PasteRequest, PasteResponse, paste
 
 log = getLogger(__name__)
@@ -547,6 +548,13 @@ class Dragonfly(commands.Cog):
         except Exception as e:
             await ctx.send(str(e))
             raise
+
+    @commands.hybrid_command(name="queue-status")
+    @commands.cooldown(1, 10, commands.BucketType.guild)
+    async def queue_status(self: Self, ctx: commands.Context[Bot]) -> None:
+        """Show cached queue health for every configured Dragonfly cluster."""
+        statuses = await fetch_cluster_queue_statuses(self.bot.dragonfly_queue_services)
+        await ctx.send(embed=build_queue_status_embed(statuses))
 
     @commands.has_role(Roles.vipyr_security)
     @commands.command()

--- a/src/bot/queue_status.py
+++ b/src/bot/queue_status.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+import discord
+
+from bot.dragonfly_services import DragonflyServices, QueueStatus
+
+log = logging.getLogger(__name__)
+
+ClusterQueueStatus = QueueStatus | Exception
+
+
+async def fetch_cluster_queue_statuses(
+    services: dict[str, DragonflyServices],
+) -> dict[str, ClusterQueueStatus]:
+    """Fetch independent cluster snapshots concurrently."""
+
+    async def fetch(name: str, service: DragonflyServices) -> tuple[str, ClusterQueueStatus]:
+        try:
+            return name, await service.get_queue_status()
+        except Exception as error:  # noqa: BLE001 - One unavailable cluster must not hide the others.
+            log.warning("Failed to fetch Dragonfly queue status for %s", name, exc_info=error)
+            return name, error
+
+    return dict(await asyncio.gather(*(fetch(name, service) for name, service in services.items())))
+
+
+def build_queue_status_embed(
+    statuses: dict[str, ClusterQueueStatus],
+    *,
+    now: datetime | None = None,
+) -> discord.Embed:
+    """Build a compact multi-cluster queue summary."""
+    current_time = now or datetime.now(tz=UTC)
+    embed = discord.Embed(title="Dragonfly queue status", color=discord.Colour.blue(), timestamp=current_time)
+
+    for cluster, snapshot in sorted(statuses.items()):
+        if isinstance(snapshot, Exception):
+            embed.add_field(name=cluster.title(), value="Unavailable", inline=False)
+            continue
+
+        oldest = "none"
+        if snapshot.oldest_queued_at is not None:
+            oldest = discord.utils.format_dt(snapshot.oldest_queued_at, "R")
+
+        sampled = discord.utils.format_dt(snapshot.sampled_at, "R")
+        value = (
+            f"Queued: **{snapshot.queued:,}** · Scanning: **{snapshot.in_progress:,}** · "
+            f"Retryable: **{snapshot.retryable:,}**\n"
+            f"Backlog: **{snapshot.total_backlog:,}** · Oldest: **{oldest}** · Sampled {sampled}"
+        )
+        embed.add_field(name=cluster.title(), value=value, inline=False)
+
+    if not statuses:
+        embed.description = "No Dragonfly clusters are configured."
+    return embed

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,14 @@
+from bot.constants import DragonflyCluster
+
+
+def test_dragonfly_cluster_redacts_access_secret() -> None:
+    cluster = DragonflyCluster.model_validate(
+        {
+            "api_url": "https://dragonfly-staging.vipyrsec.com",
+            "access_client_id": "staging-client",
+            "access_client_secret": "staging-secret",
+        }
+    )
+
+    assert cluster.access_client_secret.get_secret_value() == "staging-secret"
+    assert "staging-secret" not in repr(cluster)

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from bot.dragonfly_services import DragonflyServices, Package, PackageReport, ScanStatus
+from bot.dragonfly_services import DragonflyServices, Package, PackageReport, QueueStatus, ScanStatus
 
 
 class _MockResponse:
@@ -169,6 +169,35 @@ def test_report_package() -> None:
             "use_email": False,
         },
     )
+
+
+def test_get_queue_status() -> None:
+    service = _service()
+    sampled_at = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    service.make_request = AsyncMock(
+        return_value={
+            "queued": 12,
+            "in_progress": 2,
+            "retryable": 1,
+            "total_backlog": 13,
+            "oldest_queued_at": int((sampled_at - dt.timedelta(minutes=5)).timestamp()),
+            "oldest_age_seconds": 300,
+            "sampled_at": int(sampled_at.timestamp()),
+        }
+    )
+
+    snapshot = asyncio.run(service.get_queue_status())
+
+    assert snapshot == QueueStatus(
+        queued=12,
+        in_progress=2,
+        retryable=1,
+        total_backlog=13,
+        oldest_queued_at=sampled_at - dt.timedelta(minutes=5),
+        oldest_age_seconds=300,
+        sampled_at=sampled_at,
+    )
+    service.make_request.assert_awaited_once_with("GET", "/queue-status")
 
 
 def test_queue_package() -> None:

--- a/tests/test_queue_status.py
+++ b/tests/test_queue_status.py
@@ -1,0 +1,67 @@
+import asyncio
+import datetime as dt
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+from bot.dragonfly_services import DragonflyServices, QueueStatus
+from bot.queue_status import build_queue_status_embed, fetch_cluster_queue_statuses
+
+
+def snapshot() -> QueueStatus:
+    sampled_at = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    return QueueStatus(
+        queued=12,
+        in_progress=2,
+        retryable=1,
+        total_backlog=13,
+        oldest_queued_at=sampled_at - dt.timedelta(minutes=5),
+        oldest_age_seconds=300,
+        sampled_at=sampled_at,
+    )
+
+
+def test_fetch_cluster_queue_statuses_isolates_failures() -> None:
+    production = cast("DragonflyServices", Mock())
+    production.get_queue_status = AsyncMock(return_value=snapshot())
+    staging = cast("DragonflyServices", Mock())
+    staging.get_queue_status = AsyncMock(side_effect=RuntimeError("unavailable"))
+
+    statuses = asyncio.run(
+        fetch_cluster_queue_statuses(
+            {
+                "production": production,
+                "staging": staging,
+            }
+        )
+    )
+
+    assert statuses["production"] == snapshot()
+    assert isinstance(statuses["staging"], RuntimeError)
+
+
+def test_build_queue_status_embed() -> None:
+    now = dt.datetime(2026, 7, 25, 12, 1, tzinfo=dt.UTC)
+
+    embed = build_queue_status_embed(
+        {
+            "production": snapshot(),
+            "staging": RuntimeError("unavailable"),
+        },
+        now=now,
+    )
+
+    assert embed.title == "Dragonfly queue status"
+    assert embed.timestamp == now
+    assert embed.fields[0].name == "Production"
+    production_value = embed.fields[0].value
+    assert production_value is not None
+    assert "Queued: **12**" in production_value
+    assert "Backlog: **13**" in production_value
+    assert embed.fields[1].name == "Staging"
+    assert embed.fields[1].value == "Unavailable"
+
+
+def test_build_queue_status_embed_handles_no_clusters() -> None:
+    embed = build_queue_status_embed({})
+
+    assert embed.description == "No Dragonfly clusters are configured."


### PR DESCRIPTION
## What changed

- add a public `/queue-status` hybrid command
- fetch cached queue snapshots from configured Dragonfly clusters concurrently
- isolate cluster failures so one unavailable environment does not hide the other
- require distinct per-cluster Cloudflare Access credentials
- redact configured Access secrets from model representations

## Why

Users need a concise view of production and staging backlog without granting the bot
database access or causing user commands to run metrics queries. The command consumes
the cached endpoint introduced by vipyrsec/dragonfly-mainframe#397.

If no multi-cluster configuration is provided, the command remains backward
compatible and reports the existing primary API as `production`.

## Validation

- Ruff format and lint
- Pyright strict mode
- 52 tests
- runtime smoke test for nested JSON environment parsing
- all repository pre-commit hooks
- zizmor: no findings
