### PR TITLE
Add environment-local queue status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Vipyr Bot
 
 A Discord bot for Vipyr
+
+## Dragonfly queue status
+
+The `/queue-status` command reports the cached queue snapshot from the bot's existing
+`DRAGONFLY_API_URL`. Staging and production bots therefore report only their own
+environment using their existing environment-specific Cloudflare Access service
+token. Queue snapshots are maintained by Mainframe; invoking the command does not
+issue a metrics query against PostgreSQL.

--- a/src/bot/__main__.py
+++ b/src/bot/__main__.py
@@ -33,7 +33,6 @@ async def main() -> None:
             access_client_id=constants.Dragonfly.client_id,
             access_client_secret=constants.Dragonfly.client_secret,
         )
-
         bot = Bot(
             guild_id=constants.Guild.id,
             http_session=session,

--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -45,6 +45,19 @@ class Package(BaseModel):
         return f"{self.name} {self.version}"
 
 
+class QueueStatus(BaseModel):
+    """Cached queue summary returned by Mainframe."""
+
+    queued: int
+    in_progress: int
+    retryable: int
+    stranded: int
+    total_backlog: int
+    oldest_queued_at: datetime | None
+    oldest_age_seconds: int | None
+    sampled_at: datetime
+
+
 @dataclass
 class PackageReport:
     """Represents the payload sent to the report endpoint."""
@@ -117,6 +130,11 @@ class DragonflyServices:
 
         data = await self.make_request("GET", "/package", params=params)
         return list(map(Package.model_validate, data))
+
+    async def get_queue_status(self: Self) -> QueueStatus:
+        """Get Mainframe's latest cached queue snapshot."""
+        data = await self.make_request("GET", "/queue-status")
+        return QueueStatus.model_validate(data)
 
     async def report_package(
         self: Self,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -6,6 +6,7 @@ import logging
 import urllib.parse
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
+from json import JSONDecodeError
 from logging import getLogger
 from typing import Self
 
@@ -13,11 +14,13 @@ import aiohttp
 import discord
 import sentry_sdk
 from discord.ext import commands, tasks
+from pydantic import ValidationError
 
 from bot import constants
 from bot.bot import Bot
 from bot.constants import Channels, DragonflyConfig, Roles
 from bot.dragonfly_services import DragonflyServices, Package, PackageReport
+from bot.queue_status import build_queue_status_embed
 from bot.utils.pastebin import PasteFile, PasteRequest, PasteResponse, paste
 
 log = getLogger(__name__)
@@ -547,6 +550,19 @@ class Dragonfly(commands.Cog):
         except Exception as e:
             await ctx.send(str(e))
             raise
+
+    @commands.hybrid_command(name="queue-status")
+    @commands.cooldown(1, 10, commands.BucketType.guild)
+    async def queue_status(self: Self, ctx: commands.Context[Bot]) -> None:
+        """Show cached queue health for this bot's Dragonfly service."""
+        try:
+            snapshot = await self.bot.dragonfly_services.get_queue_status()
+        except (TimeoutError, aiohttp.ClientError, JSONDecodeError, UnicodeDecodeError, ValidationError):
+            log.warning("Failed to retrieve Dragonfly queue status", exc_info=True)
+            await ctx.send("Queue status is temporarily unavailable.")
+            return
+
+        await ctx.send(embed=build_queue_status_embed(snapshot))
 
     @commands.has_role(Roles.vipyr_security)
     @commands.command()

--- a/src/bot/queue_status.py
+++ b/src/bot/queue_status.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import discord
+
+from bot.dragonfly_services import QueueStatus
+
+
+def build_queue_status_embed(
+    snapshot: QueueStatus,
+    *,
+    now: datetime | None = None,
+) -> discord.Embed:
+    """Build a compact queue summary for this bot's Dragonfly service."""
+    current_time = now or datetime.now(tz=UTC)
+    embed = discord.Embed(title="Dragonfly queue status", color=discord.Colour.blue(), timestamp=current_time)
+
+    oldest = "none"
+    if snapshot.oldest_queued_at is not None:
+        oldest = discord.utils.format_dt(snapshot.oldest_queued_at, "R")
+
+    sampled = discord.utils.format_dt(snapshot.sampled_at, "R")
+    embed.description = (
+        f"Queued: **{snapshot.queued:,}** · Scanning: **{snapshot.in_progress:,}** · "
+        f"Retryable: **{snapshot.retryable:,}** · Stranded: **{snapshot.stranded:,}**\n"
+        f"Backlog: **{snapshot.total_backlog:,}** · Oldest: **{oldest}** · Sampled {sampled}"
+    )
+    return embed

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from bot.dragonfly_services import DragonflyServices, Package, PackageReport, ScanStatus
+from bot.dragonfly_services import DragonflyServices, Package, PackageReport, QueueStatus, ScanStatus
 
 
 class _MockResponse:
@@ -169,6 +169,37 @@ def test_report_package() -> None:
             "use_email": False,
         },
     )
+
+
+def test_get_queue_status() -> None:
+    service = _service()
+    sampled_at = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    service.make_request = AsyncMock(
+        return_value={
+            "queued": 12,
+            "in_progress": 2,
+            "retryable": 1,
+            "stranded": 0,
+            "total_backlog": 13,
+            "oldest_queued_at": int((sampled_at - dt.timedelta(minutes=5)).timestamp()),
+            "oldest_age_seconds": 300,
+            "sampled_at": int(sampled_at.timestamp()),
+        }
+    )
+
+    snapshot = asyncio.run(service.get_queue_status())
+
+    assert snapshot == QueueStatus(
+        queued=12,
+        in_progress=2,
+        retryable=1,
+        stranded=0,
+        total_backlog=13,
+        oldest_queued_at=sampled_at - dt.timedelta(minutes=5),
+        oldest_age_seconds=300,
+        sampled_at=sampled_at,
+    )
+    service.make_request.assert_awaited_once_with("GET", "/queue-status")
 
 
 def test_queue_package() -> None:

--- a/tests/test_queue_status.py
+++ b/tests/test_queue_status.py
@@ -1,0 +1,79 @@
+import asyncio
+import datetime as dt
+from collections.abc import Callable, Coroutine
+from json import JSONDecodeError
+from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from discord.ext import commands
+
+from bot.bot import Bot
+from bot.dragonfly_services import QueueStatus
+from bot.exts.dragonfly.dragonfly import Dragonfly
+from bot.queue_status import build_queue_status_embed
+
+
+def snapshot() -> QueueStatus:
+    sampled_at = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    return QueueStatus(
+        queued=12,
+        in_progress=2,
+        retryable=1,
+        stranded=0,
+        total_backlog=13,
+        oldest_queued_at=sampled_at - dt.timedelta(minutes=5),
+        oldest_age_seconds=300,
+        sampled_at=sampled_at,
+    )
+
+
+def test_build_queue_status_embed() -> None:
+    now = dt.datetime(2026, 7, 25, 12, 1, tzinfo=dt.UTC)
+
+    embed = build_queue_status_embed(snapshot(), now=now)
+
+    assert embed.title == "Dragonfly queue status"
+    assert embed.timestamp == now
+    assert embed.description is not None
+    assert "Queued: **12**" in embed.description
+    assert "Backlog: **13**" in embed.description
+
+
+def test_build_queue_status_embed_handles_no_oldest_package() -> None:
+    queue_snapshot = snapshot().model_copy(
+        update={
+            "oldest_queued_at": None,
+            "oldest_age_seconds": None,
+        }
+    )
+
+    embed = build_queue_status_embed(queue_snapshot)
+
+    assert embed.description is not None
+    assert "Oldest: **none**" in embed.description
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TimeoutError(),
+        JSONDecodeError("malformed", "", 0),
+        UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid encoding"),
+    ],
+)
+def test_queue_status_command_reports_dependency_failure(error: Exception) -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.get_queue_status = AsyncMock(side_effect=error)
+    cog = Dragonfly(bot)
+    context_mock = Mock()
+    context_mock.send = AsyncMock()
+    context = cast("commands.Context[Bot]", context_mock)
+    callback = cast(
+        "Callable[[Dragonfly, commands.Context[Bot]], Coroutine[Any, Any, None]]",
+        Dragonfly.queue_status.callback,
+    )
+
+    asyncio.run(callback(cog, context))
+
+    context_mock.send.assert_awaited_once_with("Queue status is temporarily unavailable.")


### PR DESCRIPTION
## What changed

- add a public `/queue-status` hybrid command
- read the cached snapshot from the bot's existing Dragonfly service
- show queued, actively scanning, retryable, runnable backlog, oldest age, and
  snapshot time
- report stranded rows that workers cannot reclaim
- return a user-facing temporary-unavailable message for API, timeout, or response
  validation failures, including malformed JSON and invalid response encoding

## Why

Each environment already has its own bot, Mainframe, API URL, and Cloudflare Access
service token. The command therefore reports only that bot's local Dragonfly queue;
it does not aggregate environments or cross their credential boundary.

The command consumes the cached endpoint introduced by
vipyrsec/dragonfly-mainframe#397, so it never queries PostgreSQL directly.

## Validation

- Ruff format and lint
- Pyright strict mode
- 53 tests
- all repository pre-commit hooks
- zizmor: no findings
