### PR TITLE
Move alert thresholds to Mainframe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict
@@ -42,7 +42,7 @@ repos:
           - pyi
 
   - repo: https://github.com/hadolint/hadolint
-    rev: c3dc18df7a501f02a560a2cc7ba3c69a85ca01d3  # frozen: v2.13.1-beta
+    rev: 57e1618d78fd469a92c1e584e8c9313024656623  # frozen: v2.14.0
     hooks:
       - id: hadolint
         args:
@@ -50,12 +50,12 @@ repos:
           - error
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 54da05914997e6b04e4db33ed6757d744984c68b  # frozen: 0.33.2
+    rev: 5030dca3047414c338091455ac41803200ec1f0f  # frozen: 0.37.3
     hooks:
       - id: check-github-workflows
 
   - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: 23eab0f0eedcbedebff420f5fdfb284744adc7b3  # frozen: v0.9.3
+    rev: ade0f95ddcf661c697d4670d2cfcbe95d0048a0a  # frozen: v0.9.3
     hooks:
       - id: taplo-format
       - id: taplo-lint
@@ -69,7 +69,7 @@ repos:
         files: ^pyproject\.toml$
 
   - repo: https://github.com/lyz-code/yamlfix
-    rev: 8072181c0f2eab9f2dd8db2eb3b9556d7cd0bd74  # frozen: 1.17.0
+    rev: f857ca370af3db7e5e181373d45c06a148fac3f8  # frozen: 1.19.1
     hooks:
       - id: yamlfix
         args:
@@ -77,14 +77,14 @@ repos:
           - .yamlfix.toml
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7  # frozen: v1.37.1
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
     hooks:
       - id: yamllint
         args:
           - --strict
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: 192ad822316c3a22fb3d3cc8aa6eafa0b8488360  # frozen: v0.45.0
+    rev: a4d5d37e66ebcd6b3705204a1d6dbb56dea66338  # frozen: v0.49.0
     hooks:
       - id: markdownlint-fix
 
@@ -94,7 +94,7 @@ repos:
       - id: ripsecrets
 
   - repo: https://github.com/crate-ci/typos
-    rev: 3d97dc5b9833a60a62e70d5b56af2cc7ddd522f6  # frozen: v1
+    rev: 37bb98842b0d8c4ffebdb75301a13db0267cef89  # frozen: v1.47.2
     hooks:
       - id: typos
         args: []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,6 +4,9 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+import importlib
+import inspect
+import types
 from importlib.metadata import metadata
 
 project_metadata = metadata("bot")
@@ -59,10 +62,6 @@ def linkcode_resolve(domain: str, info: dict) -> str:
         return None
     if not info["module"]:
         return None
-
-    import importlib
-    import inspect
-    import types
 
     mod = importlib.import_module(info["module"])
 

--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -74,6 +74,7 @@ class _DragonflyConfig(EnvConfig, env_prefix="dragonfly_"):
     logs_channel_id: int = 1121462677131251752
     alerts_role_id: int = 1122647527485878392
     api_url: str = "https://dragonfly.vipyrsec.com"
+    bootstrap_threshold: int = 8
     interval: int = 60
     timeout: int = 25
     inactivity_threshold: int = 60 * 10  # 10 minutes

--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -75,7 +75,6 @@ class _DragonflyConfig(EnvConfig, env_prefix="dragonfly_"):
     alerts_role_id: int = 1122647527485878392
     api_url: str = "https://dragonfly.vipyrsec.com"
     interval: int = 60
-    threshold: int = 8
     timeout: int = 25
     inactivity_threshold: int = 60 * 10  # 10 minutes
 

--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -58,6 +58,14 @@ class QueueStatus(BaseModel):
     sampled_at: datetime
 
 
+class AlertingConfiguration(BaseModel):
+    """Production alerting configuration owned by Mainframe."""
+
+    production_score_threshold: int
+    updated_at: datetime
+    updated_by: str
+
+
 @dataclass
 class PackageReport:
     """Represents the payload sent to the report endpoint."""
@@ -135,6 +143,23 @@ class DragonflyServices:
         """Get Mainframe's latest cached queue snapshot."""
         data = await self.make_request("GET", "/queue-status")
         return QueueStatus.model_validate(data)
+
+    async def get_alerting_configuration(self: Self) -> AlertingConfiguration:
+        """Get Mainframe's durable production alerting configuration."""
+        data = await self.make_request("GET", "/alerting/configuration")
+        return AlertingConfiguration.model_validate(data)
+
+    async def update_alerting_configuration(
+        self: Self,
+        production_score_threshold: int,
+    ) -> AlertingConfiguration:
+        """Update Mainframe's durable production alerting configuration."""
+        data = await self.make_request(
+            "PUT",
+            "/alerting/configuration",
+            json={"production_score_threshold": production_score_threshold},
+        )
+        return AlertingConfiguration.model_validate(data)
 
     async def report_package(
         self: Self,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -434,6 +434,7 @@ class Dragonfly(commands.Cog):
     def __init__(self: Self, bot: Bot) -> None:
         """Initialize the Dragonfly cog."""
         self.bot = bot
+        self.score_threshold: int | None = None
         self.since = datetime.now(tz=UTC) - timedelta(seconds=DragonflyConfig.interval)
         self.last_seen_package = datetime.now(tz=UTC)
         self.inactivity_alert_fired = False
@@ -470,13 +471,25 @@ class Dragonfly(commands.Cog):
         alerts_channel: discord.abc.Messageable,
     ) -> None:
         """Run one scan-loop iteration and update activity state after it succeeds."""
-        alerting_configuration = await self.bot.dragonfly_services.get_alerting_configuration()
+        try:
+            alerting_configuration = await self.bot.dragonfly_services.get_alerting_configuration()
+        except (TimeoutError, aiohttp.ClientError, JSONDecodeError, UnicodeDecodeError, ValidationError):
+            if self.score_threshold is None:
+                raise
+            log.warning(
+                "Failed to refresh the production score threshold; using the last known value.",
+                exc_info=True,
+            )
+        else:
+            self.score_threshold = alerting_configuration.production_score_threshold
+
+        assert self.score_threshold is not None
         scan_results = await run(
             self.bot,
             since=self.since,
             logs_channel=logs_channel,
             alerts_channel=alerts_channel,
-            score=alerting_configuration.production_score_threshold,
+            score=self.score_threshold,
         )
         now = datetime.now(tz=UTC)
         if scan_results:

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -309,9 +309,13 @@ class ReportView(discord.ui.View):
             await interaction.edit_original_response(view=self)
 
 
-def _build_package_scan_result_embed(scan_result: Package) -> discord.Embed:
+def _build_package_scan_result_embed(
+    scan_result: Package,
+    *,
+    production_score_threshold: int,
+) -> discord.Embed:
     """Build the embed that shows the results of a package scan."""
-    condition = (scan_result.score or 0) >= DragonflyConfig.threshold
+    condition = (scan_result.score or 0) >= production_score_threshold
     title, color = ("Malicious", 0xF70606) if condition else ("Benign", 0x4CBB17)
 
     embed = discord.Embed(
@@ -400,7 +404,10 @@ async def run(
     scan_results = await bot.dragonfly_services.get_scanned_packages(since=since)
     for result in scan_results:
         if result.score is not None and result.score >= score:
-            embed = _build_package_scan_result_embed(result)
+            embed = _build_package_scan_result_embed(
+                result,
+                production_score_threshold=score,
+            )
             await alerts_channel.send(
                 f"<@&{DragonflyConfig.alerts_role_id}>",
                 embed=embed,
@@ -427,7 +434,6 @@ class Dragonfly(commands.Cog):
     def __init__(self: Self, bot: Bot) -> None:
         """Initialize the Dragonfly cog."""
         self.bot = bot
-        self.score_threshold = DragonflyConfig.threshold
         self.since = datetime.now(tz=UTC) - timedelta(seconds=DragonflyConfig.interval)
         self.last_seen_package = datetime.now(tz=UTC)
         self.inactivity_alert_fired = False
@@ -464,12 +470,13 @@ class Dragonfly(commands.Cog):
         alerts_channel: discord.abc.Messageable,
     ) -> None:
         """Run one scan-loop iteration and update activity state after it succeeds."""
+        alerting_configuration = await self.bot.dragonfly_services.get_alerting_configuration()
         scan_results = await run(
             self.bot,
             since=self.since,
             logs_channel=logs_channel,
             alerts_channel=alerts_channel,
-            score=self.score_threshold,
+            score=alerting_configuration.production_score_threshold,
         )
         now = datetime.now(tz=UTC)
         if scan_results:
@@ -543,7 +550,11 @@ class Dragonfly(commands.Cog):
                 )
 
                 if scan_results:
-                    embed = _build_package_scan_result_embed(scan_results[0])
+                    configuration = await self.bot.dragonfly_services.get_alerting_configuration()
+                    embed = _build_package_scan_result_embed(
+                        scan_results[0],
+                        production_score_threshold=configuration.production_score_threshold,
+                    )
                     await ctx.send(f"Package `{name} v{version}` has already been scanned.", embed=embed)
                 else:
                     await ctx.send(f"Package `{name} v{version}` is already waiting to be scanned.")
@@ -612,7 +623,11 @@ class Dragonfly(commands.Cog):
 
         if scan_results:
             package = scan_results[0]
-            embed = _build_package_scan_result_embed(package)
+            configuration = await self.bot.dragonfly_services.get_alerting_configuration()
+            embed = _build_package_scan_result_embed(
+                package,
+                production_score_threshold=configuration.production_score_threshold,
+            )
 
             view = ReportView(self.bot, package)
             if not exists_on_pypi:
@@ -631,6 +646,7 @@ class Dragonfly(commands.Cog):
 
             await interaction.response.send_message("No entries were found with the specified filters.", view=view)
 
+    @commands.has_role(Roles.vipyr_security)
     @commands.group()
     async def threshold(self: Self, ctx: commands.Context[Bot]) -> None:
         """Group of commands for managing the score threshold."""
@@ -640,13 +656,14 @@ class Dragonfly(commands.Cog):
     @threshold.command()  # type: ignore[arg-type]
     async def get(self: Self, ctx: commands.Context[Bot]) -> None:
         """Get the score threshold."""
-        await ctx.send(f"The current threshold is set to `{self.score_threshold}`")
+        configuration = await self.bot.dragonfly_services.get_alerting_configuration()
+        await ctx.send(f"The current threshold is set to `{configuration.production_score_threshold}`")
 
     @threshold.command()  # type: ignore[arg-type]
     async def set(self: Self, ctx: commands.Context[Bot], value: int) -> None:
         """Set the score threshold."""
-        self.score_threshold = value
-        await ctx.send(f"The current threshold has been set to `{value}`")
+        configuration = await self.bot.dragonfly_services.update_alerting_configuration(value)
+        await ctx.send(f"The current threshold has been set to `{configuration.production_score_threshold}`")
 
 
 async def setup(bot: Bot) -> None:

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -434,7 +434,7 @@ class Dragonfly(commands.Cog):
     def __init__(self: Self, bot: Bot) -> None:
         """Initialize the Dragonfly cog."""
         self.bot = bot
-        self.score_threshold: int | None = None
+        self.score_threshold = DragonflyConfig.bootstrap_threshold
         self.since = datetime.now(tz=UTC) - timedelta(seconds=DragonflyConfig.interval)
         self.last_seen_package = datetime.now(tz=UTC)
         self.inactivity_alert_fired = False
@@ -474,8 +474,6 @@ class Dragonfly(commands.Cog):
         try:
             alerting_configuration = await self.bot.dragonfly_services.get_alerting_configuration()
         except (TimeoutError, aiohttp.ClientError, JSONDecodeError, UnicodeDecodeError, ValidationError):
-            if self.score_threshold is None:
-                raise
             log.warning(
                 "Failed to refresh the production score threshold; using the last known value.",
                 exc_info=True,
@@ -483,7 +481,6 @@ class Dragonfly(commands.Cog):
         else:
             self.score_threshold = alerting_configuration.production_score_threshold
 
-        assert self.score_threshold is not None
         scan_results = await run(
             self.bot,
             since=self.since,

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -9,7 +9,14 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from bot.dragonfly_services import DragonflyServices, Package, PackageReport, QueueStatus, ScanStatus
+from bot.dragonfly_services import (
+    AlertingConfiguration,
+    DragonflyServices,
+    Package,
+    PackageReport,
+    QueueStatus,
+    ScanStatus,
+)
 
 
 class _MockResponse:
@@ -212,4 +219,46 @@ def test_queue_package() -> None:
         "POST",
         "/package",
         json={"name": "example", "version": "1.0.0"},
+    )
+
+
+def test_get_alerting_configuration() -> None:
+    service = _service()
+    updated_at = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    service.make_request = AsyncMock(
+        return_value={
+            "production_score_threshold": 8,
+            "updated_at": int(updated_at.timestamp()),
+            "updated_by": "bot",
+        }
+    )
+
+    configuration = asyncio.run(service.get_alerting_configuration())
+
+    assert configuration == AlertingConfiguration(
+        production_score_threshold=8,
+        updated_at=updated_at,
+        updated_by="bot",
+    )
+    service.make_request.assert_awaited_once_with("GET", "/alerting/configuration")
+
+
+def test_update_alerting_configuration() -> None:
+    service = _service()
+    updated_at = dt.datetime(2026, 7, 25, 12, 0, tzinfo=dt.UTC)
+    service.make_request = AsyncMock(
+        return_value={
+            "production_score_threshold": 12,
+            "updated_at": int(updated_at.timestamp()),
+            "updated_by": "bot",
+        }
+    )
+
+    configuration = asyncio.run(service.update_alerting_configuration(12))
+
+    assert configuration.production_score_threshold == 12
+    service.make_request.assert_awaited_once_with(
+        "PUT",
+        "/alerting/configuration",
+        json={"production_score_threshold": 12},
     )

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -8,7 +8,6 @@ from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import discord
-import pytest
 
 from bot.bot import Bot
 from bot.dragonfly_services import AlertingConfiguration, Package
@@ -89,16 +88,19 @@ def test_scan_iteration_uses_last_known_threshold_during_configuration_outage() 
     assert [call.kwargs["score"] for call in run.await_args_list] == [12, 12]
 
 
-def test_scan_iteration_requires_an_initial_threshold() -> None:
-    """The bot must not invent a threshold before Mainframe responds once."""
+def test_scan_iteration_uses_bootstrap_threshold_during_startup_outage() -> None:
+    """A startup configuration outage must not stop scanning."""
     bot = cast("Bot", Mock())
     bot.dragonfly_services.get_alerting_configuration = AsyncMock(side_effect=TimeoutError("configuration unavailable"))
     cog = dragonfly.Dragonfly(bot)
     logs_channel = cast("discord.abc.Messageable", Mock())
     alerts_channel = cast("discord.abc.Messageable", Mock())
 
-    with pytest.raises(TimeoutError, match="configuration unavailable"):
+    with patch.object(dragonfly, "run", AsyncMock(return_value=[])) as run:
         asyncio.run(cog.run_scan_iteration(logs_channel=logs_channel, alerts_channel=alerts_channel))
+
+    run.assert_awaited_once()
+    assert run.await_args_list[0].kwargs["score"] == dragonfly.DragonflyConfig.bootstrap_threshold
 
 
 def test_scan_errors_alert_once_per_failure_period() -> None:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -8,6 +8,7 @@ from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import discord
+import pytest
 
 from bot.bot import Bot
 from bot.dragonfly_services import AlertingConfiguration, Package
@@ -64,6 +65,40 @@ def test_scan_iteration_alerts_once_until_activity_resumes() -> None:
         asyncio.run(cog.run_scan_iteration(logs_channel=logs_channel, alerts_channel=alerts_channel))
 
     assert not cog.inactivity_alert_fired
+
+
+def test_scan_iteration_uses_last_known_threshold_during_configuration_outage() -> None:
+    """A configuration-only outage must not stop otherwise available scanning."""
+    bot = cast("Bot", Mock())
+    configuration = AlertingConfiguration(
+        production_score_threshold=12,
+        updated_at=datetime.now(tz=UTC),
+        updated_by="test",
+    )
+    bot.dragonfly_services.get_alerting_configuration = AsyncMock(
+        side_effect=[configuration, TimeoutError("configuration unavailable")]
+    )
+    cog = dragonfly.Dragonfly(bot)
+    logs_channel = cast("discord.abc.Messageable", Mock())
+    alerts_channel = cast("discord.abc.Messageable", Mock())
+
+    with patch.object(dragonfly, "run", AsyncMock(return_value=[])) as run:
+        asyncio.run(cog.run_scan_iteration(logs_channel=logs_channel, alerts_channel=alerts_channel))
+        asyncio.run(cog.run_scan_iteration(logs_channel=logs_channel, alerts_channel=alerts_channel))
+
+    assert [call.kwargs["score"] for call in run.await_args_list] == [12, 12]
+
+
+def test_scan_iteration_requires_an_initial_threshold() -> None:
+    """The bot must not invent a threshold before Mainframe responds once."""
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.get_alerting_configuration = AsyncMock(side_effect=TimeoutError("configuration unavailable"))
+    cog = dragonfly.Dragonfly(bot)
+    logs_channel = cast("discord.abc.Messageable", Mock())
+    alerts_channel = cast("discord.abc.Messageable", Mock())
+
+    with pytest.raises(TimeoutError, match="configuration unavailable"):
+        asyncio.run(cog.run_scan_iteration(logs_channel=logs_channel, alerts_channel=alerts_channel))
 
 
 def test_scan_errors_alert_once_per_failure_period() -> None:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -10,8 +10,18 @@ from unittest.mock import AsyncMock, Mock, patch
 import discord
 
 from bot.bot import Bot
-from bot.dragonfly_services import Package
+from bot.dragonfly_services import AlertingConfiguration, Package
 from bot.exts.dragonfly import dragonfly
+
+
+def configure_alerting_api(bot: Bot, threshold: int = 8) -> None:
+    bot.dragonfly_services.get_alerting_configuration = AsyncMock(
+        return_value=AlertingConfiguration(
+            production_score_threshold=threshold,
+            updated_at=datetime.now(tz=UTC),
+            updated_by="test",
+        )
+    )
 
 
 def test_inactivity_threshold_is_inclusive() -> None:
@@ -34,6 +44,7 @@ def test_inactivity_threshold_is_inclusive() -> None:
 def test_scan_iteration_alerts_once_until_activity_resumes() -> None:
     """A continuous inactivity period must produce one alert and reset on activity."""
     bot = cast("Bot", Mock())
+    configure_alerting_api(bot)
     cog = dragonfly.Dragonfly(bot)
     cog.last_seen_package = datetime.now(tz=UTC) - timedelta(seconds=dragonfly.DragonflyConfig.inactivity_threshold + 1)
     logs_channel = cast("discord.abc.Messageable", Mock())
@@ -58,6 +69,7 @@ def test_scan_iteration_alerts_once_until_activity_resumes() -> None:
 def test_scan_errors_alert_once_per_failure_period() -> None:
     """Repeated task errors must reach Sentry without spamming Discord."""
     bot = cast("Bot", Mock())
+    configure_alerting_api(bot)
     cog = dragonfly.Dragonfly(bot)
     alerts_channel_mock = Mock()
     alerts_channel_mock.send = AsyncMock()
@@ -75,6 +87,7 @@ def test_scan_errors_alert_once_per_failure_period() -> None:
 def test_inactivity_alert_failure_preserves_successful_scan_progress() -> None:
     """Alert delivery failures must not retain the cursor or become scan errors."""
     bot = cast("Bot", Mock())
+    configure_alerting_api(bot)
     cog = dragonfly.Dragonfly(bot)
     previous_cursor = cog.since
     cog.last_seen_package = datetime.now(tz=UTC) - timedelta(seconds=dragonfly.DragonflyConfig.inactivity_threshold + 1)


### PR DESCRIPTION
## Summary

- remove the bot-local production score threshold
- read and update alerting configuration through Mainframe's authenticated API
- apply the persisted threshold consistently to scan alerts and lookup embeds
- restrict threshold commands to the Vipyr Security role
- refresh audited, full-SHA-pinned validation hooks

## Why

The bot's in-memory threshold is lost on restart and can diverge from the
threshold used for server-side metrics. Mainframe now owns this configuration
durably, giving all clients one authenticated source of truth.

This PR depends on the Mainframe alerting configuration endpoints introduced by
the companion Mainframe PR and should be deployed after they are available.

## Validation

- `uv run --locked ruff format --check .`
- `uv run --locked ruff check .`
- `uv run --locked pyright`
- `uv run --locked pytest -q` (`55 passed`)
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
