### PR TITLE
Add suppression alert controls

### DIFF
--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -1,10 +1,12 @@
 """Interacting with the Dragonfly API."""
 
 import dataclasses
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Any, Self
+from urllib.parse import quote
 
 from aiohttp import ClientSession
 from pydantic import BaseModel
@@ -64,6 +66,25 @@ class AlertingConfiguration(BaseModel):
     production_score_threshold: int
     updated_at: datetime
     updated_by: str
+
+
+class Suppression(BaseModel):
+    """A package-version alert suppression owned by Mainframe."""
+
+    suppression_id: uuid.UUID
+    package_name: str
+    package_version: str
+    rules: list[str] | None
+    created_at: datetime
+    created_by: str
+    updated_at: datetime
+    updated_by: str
+
+
+class SuppressionDeleteResponse(BaseModel):
+    """Number of suppressions deleted by Mainframe."""
+
+    deleted: int
 
 
 @dataclass
@@ -160,6 +181,75 @@ class DragonflyServices:
             json={"production_score_threshold": production_score_threshold},
         )
         return AlertingConfiguration.model_validate(data)
+
+    @staticmethod
+    def _suppression_collection_path(package_name: str, package_version: str | None = None) -> str:
+        package_path = quote(package_name, safe="")
+        if package_version is None:
+            return f"/packages/{package_path}/suppressions"
+        version_path = quote(package_version, safe="")
+        return f"/packages/{package_path}/versions/{version_path}/suppressions"
+
+    async def get_suppressions(self: Self, package_name: str) -> list[Suppression]:
+        """Get every suppression for a package across all versions."""
+        path = self._suppression_collection_path(package_name)
+        data = await self.make_request("GET", path)
+        return [Suppression.model_validate(item) for item in data]
+
+    async def get_suppression(
+        self: Self,
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+    ) -> Suppression:
+        """Get one suppression by its stable identifier."""
+        path = f"{self._suppression_collection_path(package_name, package_version)}/{suppression_id}"
+        data = await self.make_request("GET", path)
+        return Suppression.model_validate(data)
+
+    async def create_suppression(
+        self: Self,
+        package_name: str,
+        package_version: str,
+        rules: list[str] | None = None,
+    ) -> Suppression:
+        """Create a suppression; null rules suppress every rule."""
+        path = self._suppression_collection_path(package_name, package_version)
+        data = await self.make_request("POST", path, json={"rules": rules})
+        return Suppression.model_validate(data)
+
+    async def update_suppression(
+        self: Self,
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+        rules: list[str] | None,
+    ) -> Suppression:
+        """Replace one suppression's rule corpus."""
+        path = f"{self._suppression_collection_path(package_name, package_version)}/{suppression_id}"
+        data = await self.make_request("PATCH", path, json={"rules": rules})
+        return Suppression.model_validate(data)
+
+    async def delete_suppression(
+        self: Self,
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+    ) -> SuppressionDeleteResponse:
+        """Delete one suppression."""
+        path = f"{self._suppression_collection_path(package_name, package_version)}/{suppression_id}"
+        data = await self.make_request("DELETE", path)
+        return SuppressionDeleteResponse.model_validate(data)
+
+    async def delete_version_suppressions(
+        self: Self,
+        package_name: str,
+        package_version: str,
+    ) -> SuppressionDeleteResponse:
+        """Delete every suppression for one package version."""
+        path = self._suppression_collection_path(package_name, package_version)
+        data = await self.make_request("DELETE", path)
+        return SuppressionDeleteResponse.model_validate(data)
 
     async def report_package(
         self: Self,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import re
 import urllib.parse
+import uuid
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from json import JSONDecodeError
@@ -19,7 +21,7 @@ from pydantic import ValidationError
 from bot import constants
 from bot.bot import Bot
 from bot.constants import Channels, DragonflyConfig, Roles
-from bot.dragonfly_services import DragonflyServices, Package, PackageReport
+from bot.dragonfly_services import DragonflyServices, Package, PackageReport, Suppression
 from bot.queue_status import build_queue_status_embed
 from bot.utils.pastebin import PasteFile, PasteRequest, PasteResponse, paste
 
@@ -309,6 +311,47 @@ class ReportView(discord.ui.View):
             await interaction.edit_original_response(view=self)
 
 
+class AlertView(ReportView):
+    """Alert actions for a suspicious package."""
+
+    @discord.ui.button(label="Suppress", style=discord.ButtonStyle.primary)
+    async def suppress(
+        self: Self,
+        interaction: discord.Interaction[Bot],
+        button: discord.ui.Button[AlertView],
+    ) -> None:
+        """Suppress the package's currently matched rules."""
+        await interaction.response.defer()
+        rules = self.payload.rules or None
+        try:
+            suppression = await self.bot.dragonfly_services.create_suppression(
+                self.payload.name,
+                self.payload.version,
+                rules,
+            )
+        except (TimeoutError, aiohttp.ClientError, JSONDecodeError, UnicodeDecodeError, ValidationError):
+            log.warning(
+                "Failed to suppress %s v%s from its alert.",
+                self.payload.name,
+                self.payload.version,
+                exc_info=True,
+            )
+            await interaction.followup.send(
+                "The suppression could not be created. The alert remains active.",
+                ephemeral=True,
+            )
+            return
+
+        button.disabled = True
+        await interaction.edit_original_response(view=self)
+        scope = "all rules" if suppression.rules is None else f"{len(suppression.rules)} current matched rules"
+        await interaction.followup.send(
+            f"Created suppression `{suppression.suppression_id}` for `{self.payload.name}=={self.payload.version}` "
+            f"covering {scope}.",
+            ephemeral=True,
+        )
+
+
 def _build_package_scan_result_embed(
     scan_result: Package,
     *,
@@ -392,6 +435,60 @@ def inactivity_threshold_reached(
     return not alert_fired and now - last_seen_package >= timedelta(seconds=DragonflyConfig.inactivity_threshold)
 
 
+def _normalize_package_name(package_name: str) -> str:
+    """Return the normalized package name defined by PEP 503."""
+    return re.sub(r"[-_.]+", "-", package_name).lower()
+
+
+def is_suppressed(scan_result: Package, suppressions: list[Suppression]) -> bool:
+    """Return whether applicable suppressions cover every matched rule."""
+    applicable = [
+        suppression
+        for suppression in suppressions
+        if suppression.package_version == scan_result.version
+        and _normalize_package_name(suppression.package_name) == _normalize_package_name(scan_result.name)
+    ]
+    if any(suppression.rules is None for suppression in applicable):
+        return True
+
+    suppressed_rules = {rule for suppression in applicable for rule in suppression.rules or []}
+    return bool(scan_result.rules) and set(scan_result.rules) <= suppressed_rules
+
+
+def parse_suppression_rules(value: str | None) -> list[str] | None:
+    """Parse a comma-delimited rule corpus used by suppression commands."""
+    if value is None or value.strip().lower() == "all":
+        return None
+    if value.strip().lower() == "none":
+        return []
+
+    rules = [rule.strip() for rule in value.split(",")]
+    if not all(rules):
+        msg = "Rules must be comma-delimited non-empty names, or `all`/`none`."
+        raise commands.BadArgument(msg)
+    if len(rules) != len(set(rules)):
+        msg = "A suppression cannot contain duplicate rules."
+        raise commands.BadArgument(msg)
+    return rules
+
+
+def _format_suppression(suppression: Suppression) -> str:
+    """Format one suppression for compact Discord output."""
+    scope = "all rules" if suppression.rules is None else ", ".join(suppression.rules) or "no rules"
+    return f"`{suppression.suppression_id}` | `{suppression.package_name}=={suppression.package_version}` | {scope}"
+
+
+async def _send_suppression_output(ctx: commands.Context[Bot], content: str) -> None:
+    """Send suppression output directly or as a paste when it exceeds Discord's limit."""
+    if len(content) <= 2000:  # noqa: PLR2004
+        await ctx.send(content)
+        return
+
+    paste_request = PasteRequest(expiry="1day", files=[PasteFile(lexer="text", content=content)])
+    paste_response = await paste(paste_request, session=ctx.bot.http_session)
+    await ctx.send(embed=_build_pastebin_embed(paste_response))
+
+
 async def run(
     bot: Bot,
     *,
@@ -402,17 +499,35 @@ async def run(
 ) -> list[Package]:
     """Fetch and publish one iteration of package scan results."""
     scan_results = await bot.dragonfly_services.get_scanned_packages(since=since)
+    suppressions_by_package: dict[str, list[Suppression]] = {}
     for result in scan_results:
-        if result.score is not None and result.score >= score:
-            embed = _build_package_scan_result_embed(
-                result,
-                production_score_threshold=score,
-            )
-            await alerts_channel.send(
-                f"<@&{DragonflyConfig.alerts_role_id}>",
-                embed=embed,
-                view=ReportView(bot, result),
-            )
+        if result.score is None or result.score < score:
+            continue
+
+        normalized_name = _normalize_package_name(result.name)
+        if normalized_name not in suppressions_by_package:
+            try:
+                suppressions_by_package[normalized_name] = await bot.dragonfly_services.get_suppressions(result.name)
+            except (TimeoutError, aiohttp.ClientError, JSONDecodeError, UnicodeDecodeError, ValidationError):
+                log.warning(
+                    "Failed to retrieve suppressions for %s; delivering its alert.",
+                    result.name,
+                    exc_info=True,
+                )
+                suppressions_by_package[normalized_name] = []
+
+        if is_suppressed(result, suppressions_by_package[normalized_name]):
+            continue
+
+        embed = _build_package_scan_result_embed(
+            result,
+            production_score_threshold=score,
+        )
+        await alerts_channel.send(
+            f"<@&{DragonflyConfig.alerts_role_id}>",
+            embed=embed,
+            view=AlertView(bot, result),
+        )
 
     all_packages_scanned_embed = _build_all_packages_scanned_embed(scan_results)
     if len(all_packages_scanned_embed) <= 4096:  # noqa: PLR2004
@@ -441,7 +556,7 @@ class Dragonfly(commands.Cog):
         self.scan_error_alert_fired = False
         super().__init__()
 
-    @commands.hybrid_command(name="username")  # type: ignore [arg-type]
+    @commands.hybrid_command(name="username")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
     async def get_username_command(self, ctx: commands.Context[Bot]) -> None:
         """Get the username of the currently logged in user to the PyPI Observation API."""
         async with ctx.bot.http_session.get(DragonflyConfig.reporter_url + "/echo") as res:
@@ -655,6 +770,108 @@ class Dragonfly(commands.Cog):
                 view = discord.utils.MISSING
 
             await interaction.response.send_message("No entries were found with the specified filters.", view=view)
+
+    @commands.has_role(Roles.vipyr_security)
+    @commands.group(name="suppressions", aliases=("suppression",))
+    async def suppressions(self: Self, ctx: commands.Context[Bot]) -> None:
+        """Group of commands for managing package suppressions."""
+        if ctx.invoked_subcommand is None:
+            await ctx.send_help(self.suppressions)
+
+    @suppressions.command(name="list")
+    async def list_suppressions(self: Self, ctx: commands.Context[Bot], package_name: str) -> None:
+        """List every suppression for a package."""
+        suppressions = await self.bot.dragonfly_services.get_suppressions(package_name)
+        if not suppressions:
+            await ctx.send(f"No suppressions exist for `{package_name}`.")
+            return
+
+        await _send_suppression_output(
+            ctx,
+            "\n".join(_format_suppression(suppression) for suppression in suppressions),
+        )
+
+    @suppressions.command(name="view")
+    async def view_suppression(
+        self: Self,
+        ctx: commands.Context[Bot],
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+    ) -> None:
+        """View one suppression."""
+        suppression = await self.bot.dragonfly_services.get_suppression(
+            package_name,
+            package_version,
+            suppression_id,
+        )
+        await _send_suppression_output(ctx, _format_suppression(suppression))
+
+    @suppressions.command(name="create")
+    async def create_suppression(
+        self: Self,
+        ctx: commands.Context[Bot],
+        package_name: str,
+        package_version: str,
+        *,
+        rules: str | None = None,
+    ) -> None:
+        """Create a suppression, optionally scoped to comma-delimited rules."""
+        suppression = await self.bot.dragonfly_services.create_suppression(
+            package_name,
+            package_version,
+            parse_suppression_rules(rules),
+        )
+        await _send_suppression_output(ctx, f"Created suppression {_format_suppression(suppression)}")
+
+    @suppressions.command(name="modify")
+    async def modify_suppression(
+        self: Self,
+        ctx: commands.Context[Bot],
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+        *,
+        rules: str,
+    ) -> None:
+        """Replace a suppression's comma-delimited rule corpus."""
+        suppression = await self.bot.dragonfly_services.update_suppression(
+            package_name,
+            package_version,
+            suppression_id,
+            parse_suppression_rules(rules),
+        )
+        await _send_suppression_output(ctx, f"Updated suppression {_format_suppression(suppression)}")
+
+    @suppressions.command(name="delete")
+    async def delete_suppression(
+        self: Self,
+        ctx: commands.Context[Bot],
+        package_name: str,
+        package_version: str,
+        suppression_id: uuid.UUID,
+    ) -> None:
+        """Delete one suppression."""
+        await self.bot.dragonfly_services.delete_suppression(
+            package_name,
+            package_version,
+            suppression_id,
+        )
+        await ctx.send(f"Deleted suppression `{suppression_id}`.")
+
+    @suppressions.command(name="clear")
+    async def clear_suppressions(
+        self: Self,
+        ctx: commands.Context[Bot],
+        package_name: str,
+        package_version: str,
+    ) -> None:
+        """Delete every suppression for one package version."""
+        response = await self.bot.dragonfly_services.delete_version_suppressions(
+            package_name,
+            package_version,
+        )
+        await ctx.send(f"Deleted `{response.deleted}` suppressions for `{package_name}=={package_version}`.")
 
     @commands.has_role(Roles.vipyr_security)
     @commands.group()

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -322,12 +322,11 @@ class AlertView(ReportView):
     ) -> None:
         """Suppress the package's currently matched rules."""
         await interaction.response.defer()
-        rules = self.payload.rules or None
         try:
             suppression = await self.bot.dragonfly_services.create_suppression(
                 self.payload.name,
                 self.payload.version,
-                rules,
+                self.payload.rules,
             )
         except (TimeoutError, aiohttp.ClientError, JSONDecodeError, UnicodeDecodeError, ValidationError):
             log.warning(

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import uuid
 from typing import Any, Self
 from unittest.mock import AsyncMock, Mock
 
@@ -262,3 +263,91 @@ def test_update_alerting_configuration() -> None:
         "/alerting/configuration",
         json={"production_score_threshold": 12},
     )
+
+
+def _suppression_payload(
+    *,
+    suppression_id: uuid.UUID,
+    package_name: str = "example-package",
+    package_version: str = "1.0+local",
+    rules: list[str] | None = None,
+) -> dict[str, Any]:
+    timestamp = int(dt.datetime(2026, 7, 26, 12, 0, tzinfo=dt.UTC).timestamp())
+    return {
+        "suppression_id": str(suppression_id),
+        "package_name": package_name,
+        "package_version": package_version,
+        "rules": rules,
+        "created_at": timestamp,
+        "created_by": "operator",
+        "updated_at": timestamp,
+        "updated_by": "operator",
+    }
+
+
+def test_get_suppressions() -> None:
+    service = _service()
+    suppression_id = uuid.uuid4()
+    service.make_request = AsyncMock(return_value=[_suppression_payload(suppression_id=suppression_id)])
+
+    suppressions = asyncio.run(service.get_suppressions("Example Package"))
+
+    assert [suppression.suppression_id for suppression in suppressions] == [suppression_id]
+    service.make_request.assert_awaited_once_with("GET", "/packages/Example%20Package/suppressions")
+
+
+def test_get_suppression() -> None:
+    service = _service()
+    suppression_id = uuid.uuid4()
+    service.make_request = AsyncMock(return_value=_suppression_payload(suppression_id=suppression_id))
+
+    suppression = asyncio.run(service.get_suppression("example-package", "1.0+local", suppression_id))
+
+    assert suppression.suppression_id == suppression_id
+    service.make_request.assert_awaited_once_with(
+        "GET",
+        f"/packages/example-package/versions/1.0%2Blocal/suppressions/{suppression_id}",
+    )
+
+
+def test_create_and_update_suppression() -> None:
+    service = _service()
+    suppression_id = uuid.uuid4()
+    created_payload = _suppression_payload(suppression_id=suppression_id)
+    updated_payload = _suppression_payload(suppression_id=suppression_id, rules=["replacement"])
+    service.make_request = AsyncMock(side_effect=[created_payload, updated_payload])
+
+    created = asyncio.run(service.create_suppression("example-package", "1.0+local"))
+    updated = asyncio.run(
+        service.update_suppression(
+            "example-package",
+            "1.0+local",
+            suppression_id,
+            ["replacement"],
+        )
+    )
+
+    assert created.rules is None
+    assert updated.rules == ["replacement"]
+    collection_path = "/packages/example-package/versions/1.0%2Blocal/suppressions"
+    assert service.make_request.await_args_list == [
+        ((("POST", collection_path)), {"json": {"rules": None}}),
+        ((("PATCH", f"{collection_path}/{suppression_id}")), {"json": {"rules": ["replacement"]}}),
+    ]
+
+
+def test_delete_suppression_resources() -> None:
+    service = _service()
+    suppression_id = uuid.uuid4()
+    service.make_request = AsyncMock(side_effect=[{"deleted": 1}, {"deleted": 3}])
+
+    deleted_one = asyncio.run(service.delete_suppression("example", "1.0.0", suppression_id))
+    deleted_all = asyncio.run(service.delete_version_suppressions("example", "1.0.0"))
+
+    assert deleted_one.deleted == 1
+    assert deleted_all.deleted == 3
+    collection_path = "/packages/example/versions/1.0.0/suppressions"
+    assert service.make_request.await_args_list == [
+        ((("DELETE", f"{collection_path}/{suppression_id}")), {}),
+        ((("DELETE", collection_path)), {}),
+    ]

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -146,6 +146,32 @@ def test_alert_suppress_button_preserves_alert_when_mainframe_fails() -> None:
     )
 
 
+def test_alert_suppress_button_preserves_empty_rule_corpus() -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=[])
+    created = suppression(rules=[])
+    bot.dragonfly_services.create_suppression = AsyncMock(return_value=created)
+    view = dragonfly.AlertView(bot, result)
+    interaction_mock = Mock()
+    interaction_mock.response.defer = AsyncMock()
+    interaction_mock.edit_original_response = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
+
+    asyncio.run(view.suppress.callback(interaction))
+
+    bot.dragonfly_services.create_suppression.assert_awaited_once_with(
+        result.name,
+        result.version,
+        [],
+    )
+    interaction_mock.followup.send.assert_awaited_once_with(
+        f"Created suppression `{created.suppression_id}` for `Example_Package==1.0.0` "
+        "covering 0 current matched rules.",
+        ephemeral=True,
+    )
+
+
 def test_run_omits_suppressed_alert_but_keeps_scan_log() -> None:
     bot = cast("Bot", Mock())
     result = package_result(rules=["false_positive"])

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import discord
+import pytest
+from discord.ext import commands
 
 from bot.bot import Bot
-from bot.dragonfly_services import AlertingConfiguration, Package
+from bot.dragonfly_services import AlertingConfiguration, Package, ScanStatus, Suppression
 from bot.exts.dragonfly import dragonfly
 
 
@@ -22,6 +25,180 @@ def configure_alerting_api(bot: Bot, threshold: int = 8) -> None:
             updated_by="test",
         )
     )
+
+
+def package_result(*, version: str = "1.0.0", rules: list[str] | None = None) -> Package:
+    return Package(
+        scan_id="scan-id",
+        name="Example_Package",
+        version=version,
+        status=ScanStatus.FINISHED,
+        score=10,
+        inspector_url=None,
+        rules=rules or [],
+        queued_at=datetime.now(tz=UTC),
+        queued_by="test",
+        reported_at=None,
+        reported_by=None,
+        pending_at=None,
+        pending_by=None,
+        finished_at=datetime.now(tz=UTC),
+        finished_by="test",
+        commit_hash="commit",
+    )
+
+
+def suppression(*, version: str = "1.0.0", rules: list[str] | None = None) -> Suppression:
+    now = datetime.now(tz=UTC)
+    return Suppression(
+        suppression_id=uuid.uuid4(),
+        package_name="example-package",
+        package_version=version,
+        rules=rules,
+        created_at=now,
+        created_by="test",
+        updated_at=now,
+        updated_by="test",
+    )
+
+
+def test_all_rule_suppression_applies_to_matching_package_version() -> None:
+    assert dragonfly.is_suppressed(package_result(rules=["one"]), [suppression()])
+    assert not dragonfly.is_suppressed(
+        package_result(version="2.0.0", rules=["one"]),
+        [suppression()],
+    )
+
+
+def test_scoped_suppressions_combine_without_hiding_unsuppressed_rules() -> None:
+    result = package_result(rules=["one", "two"])
+
+    assert dragonfly.is_suppressed(
+        result,
+        [suppression(rules=["one"]), suppression(rules=["two"])],
+    )
+    assert not dragonfly.is_suppressed(result, [suppression(rules=["one"])])
+    assert not dragonfly.is_suppressed(package_result(rules=[]), [suppression(rules=[])])
+
+
+def test_suppression_rule_command_parser() -> None:
+    assert dragonfly.parse_suppression_rules(None) is None
+    assert dragonfly.parse_suppression_rules("all") is None
+    assert dragonfly.parse_suppression_rules("none") == []
+    assert dragonfly.parse_suppression_rules(" one, two ") == ["one", "two"]
+
+    with pytest.raises(commands.BadArgument):
+        dragonfly.parse_suppression_rules("one,")
+    with pytest.raises(commands.BadArgument):
+        dragonfly.parse_suppression_rules("one,one")
+
+
+def test_alert_suppress_button_creates_current_rule_suppression() -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=[f"false_positive_{index}" for index in range(30)])
+    created = suppression(rules=result.rules)
+    bot.dragonfly_services.create_suppression = AsyncMock(return_value=created)
+    view = dragonfly.AlertView(bot, result)
+    interaction_mock = Mock()
+    interaction_mock.response.defer = AsyncMock()
+    interaction_mock.edit_original_response = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
+
+    asyncio.run(view.suppress.callback(interaction))
+
+    button_labels = [child.label for child in view.children if isinstance(child, discord.ui.Button)]
+    assert button_labels == ["Report", "Suppress"]
+    assert view.suppress.style is discord.ButtonStyle.primary
+    assert view.suppress.disabled
+    bot.dragonfly_services.create_suppression.assert_awaited_once_with(
+        result.name,
+        result.version,
+        result.rules,
+    )
+    interaction_mock.response.defer.assert_awaited_once_with()
+    interaction_mock.edit_original_response.assert_awaited_once_with(view=view)
+    interaction_mock.followup.send.assert_awaited_once_with(
+        f"Created suppression `{created.suppression_id}` for `Example_Package==1.0.0` "
+        "covering 30 current matched rules.",
+        ephemeral=True,
+    )
+
+
+def test_alert_suppress_button_preserves_alert_when_mainframe_fails() -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=["false_positive"])
+    bot.dragonfly_services.create_suppression = AsyncMock(side_effect=TimeoutError("mainframe unavailable"))
+    view = dragonfly.AlertView(bot, result)
+    interaction_mock = Mock()
+    interaction_mock.response.defer = AsyncMock()
+    interaction_mock.edit_original_response = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
+
+    asyncio.run(view.suppress.callback(interaction))
+
+    assert not view.suppress.disabled
+    interaction_mock.edit_original_response.assert_not_awaited()
+    interaction_mock.followup.send.assert_awaited_once_with(
+        "The suppression could not be created. The alert remains active.",
+        ephemeral=True,
+    )
+
+
+def test_run_omits_suppressed_alert_but_keeps_scan_log() -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=["false_positive"])
+    bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
+    bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[suppression(rules=["false_positive"])])
+    alerts_channel_mock = Mock()
+    alerts_channel_mock.send = AsyncMock()
+    alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
+    logs_channel_mock = Mock()
+    logs_channel_mock.send = AsyncMock()
+    logs_channel = cast("discord.abc.Messageable", logs_channel_mock)
+
+    scan_results = asyncio.run(
+        dragonfly.run(
+            bot,
+            since=datetime.now(tz=UTC),
+            alerts_channel=alerts_channel,
+            logs_channel=logs_channel,
+            score=8,
+        )
+    )
+
+    assert scan_results == [result]
+    bot.dragonfly_services.get_suppressions.assert_awaited_once_with("Example_Package")
+    alerts_channel_mock.send.assert_not_awaited()
+    logs_channel_mock.send.assert_awaited_once()
+
+
+def test_run_delivers_alert_when_suppressions_are_unavailable() -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=["suspicious"])
+    bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
+    bot.dragonfly_services.get_suppressions = AsyncMock(side_effect=TimeoutError("mainframe unavailable"))
+    alerts_channel_mock = Mock()
+    alerts_channel_mock.send = AsyncMock()
+    alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
+    logs_channel_mock = Mock()
+    logs_channel_mock.send = AsyncMock()
+    logs_channel = cast("discord.abc.Messageable", logs_channel_mock)
+
+    with patch.object(dragonfly, "AlertView", return_value=Mock()):
+        asyncio.run(
+            dragonfly.run(
+                bot,
+                since=datetime.now(tz=UTC),
+                alerts_channel=alerts_channel,
+                logs_channel=logs_channel,
+                score=8,
+            )
+        )
+
+    alerts_channel_mock.send.assert_awaited_once()
+    logs_channel_mock.send.assert_awaited_once()
 
 
 def test_inactivity_threshold_is_inclusive() -> None:


### PR DESCRIPTION
## Summary

- add a typed Mainframe suppression client covering every REST operation
- evaluate package-version suppressions before publishing alerts, combining scoped rule corpora without hiding unsuppressed matches
- add role-protected commands to list, view, create, modify, delete, and clear suppressions
- add a blue, alert-only Suppress button that persists every currently matched rule, including alerts with more than 25 matches
- fail open when suppression lookup or creation is unavailable

## Why

Operators need a fast way to silence known false-positive rule hits without hiding future, unrelated detections. Suppression management also needs a durable tuning path after the initial one-click action.

## Impact

Alert messages gain a one-click Suppress action. A scoped suppression hides an alert only when its matched rules are fully covered; an all-rule suppression always applies. Lookup messages retain their existing Report-only controls.

Requires vipyrsec/dragonfly-mainframe#400 to deploy first.

## Validation

- 69 pytest tests
- Ruff and full Pyright checks
- `ty` checks across the changed Bot surface
- complete audited `prek` hook suite
- pedantic offline `zizmor` with no findings
