### PR TITLE
Expose suppression management as slash commands

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -28,6 +28,14 @@ from bot.utils.pastebin import PasteFile, PasteRequest, PasteResponse, paste
 log = getLogger(__name__)
 log.setLevel(logging.INFO)
 
+SUPPRESSION_SERVICE_ERRORS = (
+    TimeoutError,
+    aiohttp.ClientError,
+    JSONDecodeError,
+    UnicodeDecodeError,
+    ValidationError,
+)
+
 
 def _build_modal_title(name: str, version: str) -> str:
     """Build the modal title."""
@@ -547,7 +555,7 @@ def _build_suppression_list_embeds(package_name: str, suppressions: list[Suppres
             )
         ]
 
-    per_page = 10
+    per_page = 8
     page_count = (len(suppressions) + per_page - 1) // per_page
     embeds: list[discord.Embed] = []
     for page, start in enumerate(range(0, len(suppressions), per_page), start=1):
@@ -610,6 +618,31 @@ def _build_suppressions_cleared_embed(
     return embed
 
 
+class SuppressionCommandGroup(discord.app_commands.Group):
+    """Application-command group with operator-facing error handling."""
+
+    async def on_error(
+        self: Self,
+        interaction: discord.Interaction[Bot],
+        error: discord.app_commands.AppCommandError,
+    ) -> None:
+        """Return an actionable ephemeral response for suppression command failures."""
+        cause = error.original if isinstance(error, discord.app_commands.CommandInvokeError) else error
+        if isinstance(cause, discord.app_commands.CheckFailure):
+            message = "You are not authorized to manage suppressions."
+        elif isinstance(cause, SUPPRESSION_SERVICE_ERRORS):
+            log.warning("Mainframe failed to complete a suppression command.", exc_info=cause)
+            message = "Mainframe could not complete the suppression request. No changes were confirmed."
+        else:
+            log.error("Unexpected suppression command failure.", exc_info=cause)
+            message = "The suppression request failed unexpectedly. No changes were confirmed."
+
+        if interaction.response.is_done():
+            await interaction.followup.send(message, ephemeral=True)
+        else:
+            await interaction.response.send_message(message, ephemeral=True)
+
+
 async def run(
     bot: Bot,
     *,
@@ -667,7 +700,7 @@ async def run(
 class Dragonfly(commands.Cog):
     """Cog for the Dragonfly scanner."""
 
-    suppressions = discord.app_commands.Group(
+    suppressions = SuppressionCommandGroup(
         name="suppressions",
         description="Manage package alert suppressions",
     )

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -20,7 +20,7 @@ from pydantic import ValidationError
 
 from bot import constants
 from bot.bot import Bot
-from bot.constants import Channels, DragonflyConfig, Roles
+from bot.constants import Channels, Colours, DragonflyConfig, Roles
 from bot.dragonfly_services import DragonflyServices, Package, PackageReport, Suppression
 from bot.queue_status import build_queue_status_embed
 from bot.utils.pastebin import PasteFile, PasteRequest, PasteResponse, paste
@@ -471,21 +471,143 @@ def parse_suppression_rules(value: str | None) -> list[str] | None:
     return rules
 
 
-def _format_suppression(suppression: Suppression) -> str:
-    """Format one suppression for compact Discord output."""
-    scope = "all rules" if suppression.rules is None else ", ".join(suppression.rules) or "no rules"
-    return f"`{suppression.suppression_id}` | `{suppression.package_name}=={suppression.package_version}` | {scope}"
+def _inline_code(value: str, *, limit: int = 100) -> str:
+    """Format bounded external text as inline code without allowing delimiter injection."""
+    escaped = value.replace("`", "'")
+    if len(escaped) > limit:
+        escaped = escaped[: limit - 1] + "…"
+    return f"`{escaped}`"
 
 
-async def _send_suppression_output(ctx: commands.Context[Bot], content: str) -> None:
-    """Send suppression output directly or as a paste when it exceeds Discord's limit."""
-    if len(content) <= 2000:  # noqa: PLR2004
-        await ctx.send(content)
-        return
+def _format_suppression_rules(rules: list[str] | None, *, limit: int = 900) -> str:
+    """Format a bounded rule preview for an embed field."""
+    if rules is None:
+        return "Every current and future alert rule."
+    if not rules:
+        return "_No rules selected._"
 
-    paste_request = PasteRequest(expiry="1day", files=[PasteFile(lexer="text", content=content)])
-    paste_response = await paste(paste_request, session=ctx.bot.http_session)
-    await ctx.send(embed=_build_pastebin_embed(paste_response))
+    rendered: list[str] = []
+    for index, rule in enumerate(rules):
+        candidate = ", ".join([*rendered, _inline_code(rule)])
+        remaining = len(rules) - index - 1
+        suffix = f"\n_+{remaining} more_" if remaining else ""
+        if len(candidate) + len(suffix) > limit:
+            break
+        rendered.append(_inline_code(rule))
+
+    omitted = len(rules) - len(rendered)
+    preview = ", ".join(rendered)
+    if omitted:
+        preview += f"\n_+{omitted} more_"
+    return preview
+
+
+def _suppression_scope(suppression: Suppression) -> str:
+    """Summarize the number of rules covered by a suppression."""
+    if suppression.rules is None:
+        return "All rules"
+    return f"{len(suppression.rules)} selected rule{'s' if len(suppression.rules) != 1 else ''}"
+
+
+def _build_suppression_embed(suppression: Suppression, *, title: str) -> discord.Embed:
+    """Build a detailed embed for one suppression."""
+    embed = discord.Embed(
+        title=title,
+        description=(
+            f"**Package:** {_inline_code(suppression.package_name)}\n"
+            f"**Version:** {_inline_code(suppression.package_version)}"
+        ),
+        color=Colours.blue,
+        timestamp=suppression.updated_at,
+    )
+    embed.add_field(name="Scope", value=_suppression_scope(suppression), inline=False)
+    embed.add_field(name="Rules", value=_format_suppression_rules(suppression.rules), inline=False)
+    embed.add_field(name="Suppression ID", value=_inline_code(str(suppression.suppression_id)), inline=False)
+    embed.add_field(
+        name="Created",
+        value=f"{discord.utils.format_dt(suppression.created_at, 'f')} by {_inline_code(suppression.created_by)}",
+        inline=False,
+    )
+    embed.add_field(
+        name="Updated",
+        value=f"{discord.utils.format_dt(suppression.updated_at, 'R')} by {_inline_code(suppression.updated_by)}",
+        inline=False,
+    )
+    return embed
+
+
+def _build_suppression_list_embeds(package_name: str, suppressions: list[Suppression]) -> list[discord.Embed]:
+    """Build bounded summary embeds for every suppression against a package."""
+    if not suppressions:
+        return [
+            discord.Embed(
+                title="No suppressions found",
+                description=f"No suppressions exist for {_inline_code(package_name)}.",
+                color=Colours.blue,
+            )
+        ]
+
+    per_page = 10
+    page_count = (len(suppressions) + per_page - 1) // per_page
+    embeds: list[discord.Embed] = []
+    for page, start in enumerate(range(0, len(suppressions), per_page), start=1):
+        embed = discord.Embed(
+            title=f"Suppressions · {package_name}"[:256],
+            description=f"{len(suppressions)} suppression{'s' if len(suppressions) != 1 else ''} found.",
+            color=Colours.blue,
+        )
+        for suppression in suppressions[start : start + per_page]:
+            embed.add_field(
+                name=f"{suppression.package_version} · {_suppression_scope(suppression)}"[:256],
+                value=(
+                    f"**ID:** {_inline_code(str(suppression.suppression_id))}\n"
+                    f"**Rules:** {_format_suppression_rules(suppression.rules, limit=350)}"
+                ),
+                inline=False,
+            )
+        embed.set_footer(text=f"Page {page}/{page_count}")
+        embeds.append(embed)
+    return embeds
+
+
+async def _send_suppression_list(
+    interaction: discord.Interaction[Bot],
+    package_name: str,
+    suppressions: list[Suppression],
+) -> None:
+    """Send each bounded suppression list page as an ephemeral embed."""
+    for embed in _build_suppression_list_embeds(package_name, suppressions):
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+def _build_suppression_deleted_embed(
+    package_name: str,
+    package_version: str,
+    suppression_id: uuid.UUID,
+) -> discord.Embed:
+    """Build confirmation for deletion of one suppression."""
+    embed = discord.Embed(
+        title="Suppression deleted",
+        description=f"{_inline_code(package_name)} version {_inline_code(package_version)}",
+        color=Colours.soft_green,
+    )
+    embed.add_field(name="Suppression ID", value=_inline_code(str(suppression_id)), inline=False)
+    return embed
+
+
+def _build_suppressions_cleared_embed(
+    package_name: str,
+    package_version: str,
+    deleted: int,
+) -> discord.Embed:
+    """Build confirmation for deletion of a version's suppressions."""
+    embed = discord.Embed(
+        title="Suppressions cleared",
+        description=f"{_inline_code(package_name)} version {_inline_code(package_version)}",
+        color=Colours.soft_green,
+    )
+    embed.add_field(name="Deleted", value=str(deleted), inline=False)
+    return embed
 
 
 async def run(
@@ -544,6 +666,11 @@ async def run(
 
 class Dragonfly(commands.Cog):
     """Cog for the Dragonfly scanner."""
+
+    suppressions = discord.app_commands.Group(
+        name="suppressions",
+        description="Manage package alert suppressions",
+    )
 
     def __init__(self: Self, bot: Bot) -> None:
         """Initialize the Dragonfly cog."""
@@ -770,107 +897,176 @@ class Dragonfly(commands.Cog):
 
             await interaction.response.send_message("No entries were found with the specified filters.", view=view)
 
-    @commands.has_role(Roles.vipyr_security)
-    @commands.group(name="suppressions", aliases=("suppression",))
-    async def suppressions(self: Self, ctx: commands.Context[Bot]) -> None:
-        """Group of commands for managing package suppressions."""
-        if ctx.invoked_subcommand is None:
-            await ctx.send_help(self.suppressions)
-
+    @discord.app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
     @suppressions.command(name="list")
-    async def list_suppressions(self: Self, ctx: commands.Context[Bot], package_name: str) -> None:
+    @discord.app_commands.describe(package_name="Package whose suppressions should be listed")
+    async def list_suppressions(
+        self: Self,
+        interaction: discord.Interaction[Bot],
+        package_name: str,
+    ) -> None:
         """List every suppression for a package."""
+        await interaction.response.defer(thinking=True, ephemeral=True)
         suppressions = await self.bot.dragonfly_services.get_suppressions(package_name)
-        if not suppressions:
-            await ctx.send(f"No suppressions exist for `{package_name}`.")
-            return
+        await _send_suppression_list(interaction, package_name, suppressions)
 
-        await _send_suppression_output(
-            ctx,
-            "\n".join(_format_suppression(suppression) for suppression in suppressions),
-        )
-
+    @discord.app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
     @suppressions.command(name="view")
+    @discord.app_commands.describe(
+        package_name="Suppressed package",
+        package_version="Suppressed package version",
+        suppression_id="Suppression UUID",
+    )
     async def view_suppression(
         self: Self,
-        ctx: commands.Context[Bot],
+        interaction: discord.Interaction[Bot],
         package_name: str,
         package_version: str,
-        suppression_id: uuid.UUID,
+        suppression_id: str,
     ) -> None:
         """View one suppression."""
+        try:
+            parsed_id = uuid.UUID(suppression_id)
+        except ValueError:
+            await interaction.response.send_message("The suppression ID must be a valid UUID.", ephemeral=True)
+            return
+
+        await interaction.response.defer(thinking=True, ephemeral=True)
         suppression = await self.bot.dragonfly_services.get_suppression(
             package_name,
             package_version,
-            suppression_id,
+            parsed_id,
         )
-        await _send_suppression_output(ctx, _format_suppression(suppression))
+        await interaction.followup.send(
+            embed=_build_suppression_embed(suppression, title="Suppression details"),
+            ephemeral=True,
+        )
 
+    @discord.app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
     @suppressions.command(name="create")
+    @discord.app_commands.describe(
+        package_name="Package to suppress",
+        package_version="Package version to suppress",
+        rules="Comma-delimited rules, `all`, or `none`; defaults to all",
+    )
     async def create_suppression(
         self: Self,
-        ctx: commands.Context[Bot],
+        interaction: discord.Interaction[Bot],
         package_name: str,
         package_version: str,
-        *,
         rules: str | None = None,
     ) -> None:
         """Create a suppression, optionally scoped to comma-delimited rules."""
+        try:
+            parsed_rules = parse_suppression_rules(rules)
+        except commands.BadArgument as error:
+            await interaction.response.send_message(str(error), ephemeral=True)
+            return
+
+        await interaction.response.defer(thinking=True, ephemeral=True)
         suppression = await self.bot.dragonfly_services.create_suppression(
             package_name,
             package_version,
-            parse_suppression_rules(rules),
+            parsed_rules,
         )
-        await _send_suppression_output(ctx, f"Created suppression {_format_suppression(suppression)}")
+        await interaction.followup.send(
+            embed=_build_suppression_embed(suppression, title="Suppression created"),
+            ephemeral=True,
+        )
 
+    @discord.app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
     @suppressions.command(name="modify")
+    @discord.app_commands.describe(
+        package_name="Suppressed package",
+        package_version="Suppressed package version",
+        suppression_id="Suppression UUID",
+        rules="Comma-delimited rules, `all`, or `none`",
+    )
     async def modify_suppression(
         self: Self,
-        ctx: commands.Context[Bot],
+        interaction: discord.Interaction[Bot],
         package_name: str,
         package_version: str,
-        suppression_id: uuid.UUID,
-        *,
+        suppression_id: str,
         rules: str,
     ) -> None:
         """Replace a suppression's comma-delimited rule corpus."""
+        try:
+            parsed_id = uuid.UUID(suppression_id)
+            parsed_rules = parse_suppression_rules(rules)
+        except ValueError:
+            await interaction.response.send_message("The suppression ID must be a valid UUID.", ephemeral=True)
+            return
+        except commands.BadArgument as error:
+            await interaction.response.send_message(str(error), ephemeral=True)
+            return
+
+        await interaction.response.defer(thinking=True, ephemeral=True)
         suppression = await self.bot.dragonfly_services.update_suppression(
             package_name,
             package_version,
-            suppression_id,
-            parse_suppression_rules(rules),
+            parsed_id,
+            parsed_rules,
         )
-        await _send_suppression_output(ctx, f"Updated suppression {_format_suppression(suppression)}")
+        await interaction.followup.send(
+            embed=_build_suppression_embed(suppression, title="Suppression updated"),
+            ephemeral=True,
+        )
 
+    @discord.app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
     @suppressions.command(name="delete")
+    @discord.app_commands.describe(
+        package_name="Suppressed package",
+        package_version="Suppressed package version",
+        suppression_id="Suppression UUID",
+    )
     async def delete_suppression(
         self: Self,
-        ctx: commands.Context[Bot],
+        interaction: discord.Interaction[Bot],
         package_name: str,
         package_version: str,
-        suppression_id: uuid.UUID,
+        suppression_id: str,
     ) -> None:
         """Delete one suppression."""
+        try:
+            parsed_id = uuid.UUID(suppression_id)
+        except ValueError:
+            await interaction.response.send_message("The suppression ID must be a valid UUID.", ephemeral=True)
+            return
+
+        await interaction.response.defer(thinking=True, ephemeral=True)
         await self.bot.dragonfly_services.delete_suppression(
             package_name,
             package_version,
-            suppression_id,
+            parsed_id,
         )
-        await ctx.send(f"Deleted suppression `{suppression_id}`.")
+        await interaction.followup.send(
+            embed=_build_suppression_deleted_embed(package_name, package_version, parsed_id),
+            ephemeral=True,
+        )
 
+    @discord.app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
     @suppressions.command(name="clear")
+    @discord.app_commands.describe(
+        package_name="Package whose suppressions should be deleted",
+        package_version="Package version whose suppressions should be deleted",
+    )
     async def clear_suppressions(
         self: Self,
-        ctx: commands.Context[Bot],
+        interaction: discord.Interaction[Bot],
         package_name: str,
         package_version: str,
     ) -> None:
         """Delete every suppression for one package version."""
+        await interaction.response.defer(thinking=True, ephemeral=True)
         response = await self.bot.dragonfly_services.delete_version_suppressions(
             package_name,
             package_version,
         )
-        await ctx.send(f"Deleted `{response.deleted}` suppressions for `{package_name}=={package_version}`.")
+        await interaction.followup.send(
+            embed=_build_suppressions_cleared_embed(package_name, package_version, response.deleted),
+            ephemeral=True,
+        )
 
     @commands.has_role(Roles.vipyr_security)
     @commands.group()

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import discord
 import pytest
+from discord import app_commands
 from discord.ext import commands
 
 from bot.bot import Bot
@@ -91,6 +93,111 @@ def test_suppression_rule_command_parser() -> None:
         dragonfly.parse_suppression_rules("one,")
     with pytest.raises(commands.BadArgument):
         dragonfly.parse_suppression_rules("one,one")
+
+
+def test_suppressions_are_registered_as_slash_commands_only() -> None:
+    group = dragonfly.Dragonfly.suppressions
+
+    assert isinstance(group, app_commands.Group)
+    assert group.name == "suppressions"
+    assert {command.name for command in group.commands} == {
+        "clear",
+        "create",
+        "delete",
+        "list",
+        "modify",
+        "view",
+    }
+    assert all(command.checks for command in group.commands if isinstance(command, app_commands.Command))
+    assert "suppressions" not in {command.name for command in dragonfly.Dragonfly.__cog_commands__}
+
+
+def test_create_suppression_slash_command_defaults_to_all_rules() -> None:
+    bot = cast("Bot", Mock())
+    created = suppression()
+    bot.dragonfly_services.create_suppression = AsyncMock(return_value=created)
+
+    interaction = _invoke_suppression_command("create", bot, "Example_Package", "1.0.0")
+
+    bot.dragonfly_services.create_suppression.assert_awaited_once_with(
+        "Example_Package",
+        "1.0.0",
+        None,
+    )
+    interaction.response.defer.assert_awaited_once_with(thinking=True, ephemeral=True)
+    sent_embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert sent_embed.title == "Suppression created"
+    assert sent_embed.description == "**Package:** `example-package`\n**Version:** `1.0.0`"
+    assert [(field.name, field.value) for field in sent_embed.fields[:3]] == [
+        ("Scope", "All rules"),
+        ("Rules", "Every current and future alert rule."),
+        ("Suppression ID", f"`{created.suppression_id}`"),
+    ]
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+def test_suppression_embeds_bound_large_rule_corpora_and_lists() -> None:
+    rules = [f"false_positive_rule_{index:02d}" for index in range(30)]
+    suppressions = [suppression(version=f"1.0.{index}", rules=rules) for index in range(11)]
+
+    details = dragonfly._build_suppression_embed(  # noqa: SLF001
+        suppressions[0],
+        title="Suppression details",
+    )
+    pages = dragonfly._build_suppression_list_embeds("example-package", suppressions)  # noqa: SLF001
+
+    assert details.title == "Suppression details"
+    assert details.fields[0].value == "30 selected rules"
+    assert details.fields[1].value is not None
+    assert len(details.fields[1].value) <= 900
+    assert len(pages) == 2
+    assert [len(page.fields) for page in pages] == [10, 1]
+    assert [page.footer.text for page in pages] == ["Page 1/2", "Page 2/2"]
+    assert all(field.value is not None and len(field.value) <= 1024 for page in pages for field in page.fields)
+
+
+def test_list_suppressions_slash_command_sends_embed_pages() -> None:
+    bot = cast("Bot", Mock())
+    suppressions = [suppression(version=f"1.0.{index}", rules=["one", "two"]) for index in range(11)]
+    bot.dragonfly_services.get_suppressions = AsyncMock(return_value=suppressions)
+
+    interaction = _invoke_suppression_command("list", bot, "example-package")
+
+    interaction.response.defer.assert_awaited_once_with(thinking=True, ephemeral=True)
+    assert interaction.followup.send.await_count == 2
+    sent_embeds = [call.kwargs["embed"] for call in interaction.followup.send.await_args_list]
+    assert [embed.footer.text for embed in sent_embeds] == ["Page 1/2", "Page 2/2"]
+    assert all(call.kwargs["ephemeral"] is True for call in interaction.followup.send.await_args_list)
+
+
+def test_view_suppression_slash_command_rejects_invalid_uuid() -> None:
+    bot = cast("Bot", Mock())
+    get_suppression = AsyncMock()
+    bot.dragonfly_services.get_suppression = get_suppression
+
+    interaction = _invoke_suppression_command("view", bot, "example-package", "1.0.0", "not-a-uuid")
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "The suppression ID must be a valid UUID.",
+        ephemeral=True,
+    )
+    interaction.response.defer.assert_not_awaited()
+    get_suppression.assert_not_called()
+
+
+def _invoke_suppression_command(command_name: str, bot: Bot, *args: str) -> Mock:
+    """Invoke a decorated suppression application-command callback."""
+    command = dragonfly.Dragonfly.suppressions.get_command(command_name)
+    assert isinstance(command, app_commands.Command)
+    callback = cast("Callable[..., Coroutine[Any, Any, None]]", command.callback)
+    interaction_mock = Mock()
+    interaction_mock.response.defer = AsyncMock()
+    interaction_mock.response.send_message = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
+
+    asyncio.run(callback(dragonfly.Dragonfly(bot), interaction, *args))
+    return interaction_mock
 
 
 def test_alert_suppress_button_creates_current_rule_suppression() -> None:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -151,9 +151,22 @@ def test_suppression_embeds_bound_large_rule_corpora_and_lists() -> None:
     assert details.fields[1].value is not None
     assert len(details.fields[1].value) <= 900
     assert len(pages) == 2
-    assert [len(page.fields) for page in pages] == [10, 1]
+    assert [len(page.fields) for page in pages] == [8, 3]
     assert [page.footer.text for page in pages] == ["Page 1/2", "Page 2/2"]
+    assert all(len(page) <= 6000 for page in pages)
     assert all(field.value is not None and len(field.value) <= 1024 for page in pages for field in page.fields)
+
+
+def test_suppression_list_pages_stay_within_aggregate_embed_limit() -> None:
+    suppressions = [
+        suppression(version=f"{index}-{'v' * 500}", rules=[f"{rule}-{'r' * 500}" for rule in range(30)])
+        for index in range(9)
+    ]
+
+    pages = dragonfly._build_suppression_list_embeds("p" * 500, suppressions)  # noqa: SLF001
+
+    assert [len(page.fields) for page in pages] == [8, 1]
+    assert all(len(page) <= 6000 for page in pages)
 
 
 def test_list_suppressions_slash_command_sends_embed_pages() -> None:
@@ -168,6 +181,26 @@ def test_list_suppressions_slash_command_sends_embed_pages() -> None:
     sent_embeds = [call.kwargs["embed"] for call in interaction.followup.send.await_args_list]
     assert [embed.footer.text for embed in sent_embeds] == ["Page 1/2", "Page 2/2"]
     assert all(call.kwargs["ephemeral"] is True for call in interaction.followup.send.await_args_list)
+
+
+def test_suppression_group_reports_deferred_service_failure() -> None:
+    group = dragonfly.Dragonfly.suppressions
+    command = group.get_command("list")
+    assert isinstance(command, app_commands.Command)
+    interaction_mock = Mock()
+    interaction_mock.response.is_done.return_value = True
+    interaction_mock.response.send_message = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
+    error = app_commands.CommandInvokeError(command, TimeoutError("mainframe unavailable"))
+
+    asyncio.run(dragonfly.SuppressionCommandGroup.on_error(group, interaction, error))
+
+    interaction_mock.followup.send.assert_awaited_once_with(
+        "Mainframe could not complete the suppression request. No changes were confirmed.",
+        ephemeral=True,
+    )
+    interaction_mock.response.send_message.assert_not_awaited()
 
 
 def test_view_suppression_slash_command_rejects_invalid_uuid() -> None:


### PR DESCRIPTION
## Summary

- replace the prefix-only suppression command group with `/suppressions`
- expose `list`, `view`, `create`, `modify`, `delete`, and `clear` as application-command subcommands
- render suppression details, paginated lists, and deletion confirmations as bounded ephemeral embeds
- preserve Vipyr Security role checks and existing rule-tuning semantics

## Root cause

The suppression management commands were registered with `discord.ext.commands.group`, so they never entered Discord's application-command tree and could not be registered by the Bot's sync command.

## User impact

Operators can manage suppressions through the Bot's standard slash-command interface. Large rule corpora and suppression lists remain readable without exceeding Discord embed limits.

## Validation

- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run pytest -q` (74 passed)
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run ruff check src/bot/exts/dragonfly/dragonfly.py tests/test_scan_alerting.py`
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run ruff format --check src/bot/exts/dragonfly/dragonfly.py tests/test_scan_alerting.py`
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run ty check src/bot/exts/dragonfly/dragonfly.py tests/test_scan_alerting.py`
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
