### PR TITLE
Apply rule suppressions across package versions

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -448,17 +448,19 @@ def _normalize_package_name(package_name: str) -> str:
 
 
 def is_suppressed(scan_result: Package, suppressions: list[Suppression]) -> bool:
-    """Return whether applicable suppressions cover every matched rule."""
-    applicable = [
+    """Return whether package-wide rule suppressions cover every matched rule."""
+    package_suppressions = [
         suppression
         for suppression in suppressions
-        if suppression.package_version == scan_result.version
-        and _normalize_package_name(suppression.package_name) == _normalize_package_name(scan_result.name)
+        if _normalize_package_name(suppression.package_name) == _normalize_package_name(scan_result.name)
     ]
-    if any(suppression.rules is None for suppression in applicable):
+    if any(
+        suppression.rules is None and suppression.package_version == scan_result.version
+        for suppression in package_suppressions
+    ):
         return True
 
-    suppressed_rules = {rule for suppression in applicable for rule in suppression.rules or []}
+    suppressed_rules = {rule for suppression in package_suppressions for rule in suppression.rules or []}
     return bool(scan_result.rules) and set(scan_result.rules) <= suppressed_rules
 
 

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -64,7 +64,7 @@ def suppression(*, version: str = "1.0.0", rules: list[str] | None = None) -> Su
     )
 
 
-def test_all_rule_suppression_applies_to_matching_package_version() -> None:
+def test_all_rule_suppression_applies_only_to_matching_package_version() -> None:
     assert dragonfly.is_suppressed(package_result(rules=["one"]), [suppression()])
     assert not dragonfly.is_suppressed(
         package_result(version="2.0.0", rules=["one"]),
@@ -72,15 +72,25 @@ def test_all_rule_suppression_applies_to_matching_package_version() -> None:
     )
 
 
-def test_scoped_suppressions_combine_without_hiding_unsuppressed_rules() -> None:
-    result = package_result(rules=["one", "two"])
+def test_scoped_suppressions_apply_across_versions_and_combine() -> None:
+    result = package_result(version="3.0.0", rules=["one", "two"])
 
     assert dragonfly.is_suppressed(
         result,
-        [suppression(rules=["one"]), suppression(rules=["two"])],
+        [
+            suppression(version="1.0.0", rules=["one"]),
+            suppression(version="2.0.0", rules=["two"]),
+        ],
     )
     assert not dragonfly.is_suppressed(result, [suppression(rules=["one"])])
     assert not dragonfly.is_suppressed(package_result(rules=[]), [suppression(rules=[])])
+
+
+def test_scoped_suppression_does_not_apply_to_another_package() -> None:
+    other_package = suppression(rules=["one"])
+    other_package.package_name = "different-package"
+
+    assert not dragonfly.is_suppressed(package_result(rules=["one"]), [other_package])
 
 
 def test_suppression_rule_command_parser() -> None:


### PR DESCRIPTION
## Summary

- apply explicit suppression rule corpora across every version of the same normalized package
- combine rule corpora from multiple suppression records when evaluating a package
- keep untuned all-rule suppressions limited to their recorded package version
- preserve the requirement that every matched alert rule must be covered

## Root cause

Suppression evaluation filtered every record by exact package version before considering its rule corpus. Staging therefore ignored the `hol-guard==2.2.0a57` suppression for `2.2.0a58` and `2.2.0a59`, even though all three scans matched the same 56 rules.

## User impact

The existing tuned `hol-guard` suppression now covers later package versions with the same matched rules. A later version still alerts when it introduces any rule not covered by the package's accumulated suppression corpus.

## Validation

- live staging comparison confirmed identical 56-rule corpora for `hol-guard` versions `2.2.0a57`, `2.2.0a58`, and `2.2.0a59`
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run pytest -q` (77 passed)
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run ruff check src/bot/exts/dragonfly/dragonfly.py tests/test_scan_alerting.py`
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run ruff format --check src/bot/exts/dragonfly/dragonfly.py tests/test_scan_alerting.py`
- `UV_CACHE_DIR=/tmp/vipyrsec-bot-uv-cache uv run ty check src/bot/exts/dragonfly/dragonfly.py tests/test_scan_alerting.py`
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
