### PR TITLE
Add sandbox analysis slash command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .ONESHELL:
 .SILENT:
 .DEFAULT_GOAL = help
+SHELL := /bin/bash
+.SHELLFLAGS := -eu -o pipefail -c
 
 PYTHON_FILES = $(shell find src/ tests/ -type f -name '*.py')
 
@@ -11,12 +13,10 @@ all: format lint test ## Format, lint, and run tests
 format: $(PYTHON_FILES) ## Format Python files
 	uv run --locked ruff format $?
 
-LINT_OPTIONS = --fix # Fix the lint violations
-
 .PHONY: lint
 lint: $(PYTHON_FILES) ## Lint Python files
 	uv run --locked pyright
-	uv run --locked ruff check $(LINT_OPTIONS) $?
+	uv run --locked ruff check $(PYTHON_FILES)
 
 .PHONY: test
 test: $(PYTHON_FILES) ## Run tests in Docker

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ The `/queue-status` command reports the cached queue snapshot from the bot's exi
 environment using their existing environment-specific Cloudflare Access service
 token. Queue snapshots are maintained by Mainframe; invoking the command does not
 issue a metrics query against PostgreSQL.
+
+## Sandbox analysis
+
+The role-restricted `/sandbox` command queues an exact package release for analysis
+at `https://sandbox.vipyrsec.com`. Configure the bot with `SANDBOX_API_KEY`; the
+credential is read only at runtime and sent as a bearer token to `/v1/triage`.

--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -8,7 +8,7 @@ An `.env` file is used to populate env vars, if present.
 from os import getenv
 from typing import ClassVar
 
-from pydantic import field_validator
+from pydantic import SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -83,6 +83,15 @@ class _DragonflyConfig(EnvConfig, env_prefix="dragonfly_"):
 
 
 DragonflyConfig = _DragonflyConfig()
+
+
+class _Sandbox(EnvConfig, env_prefix="sandbox_"):
+    """Snakehook sandbox configuration."""
+
+    api_key: SecretStr = SecretStr("")
+
+
+Sandbox = _Sandbox()
 
 
 class _PyPi(EnvConfig, env_prefix="pypi_"):

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -519,7 +519,7 @@ def _suppression_scope(suppression: Suppression) -> str:
     return f"{len(suppression.rules)} selected rule{'s' if len(suppression.rules) != 1 else ''}"
 
 
-def _build_suppression_embed(suppression: Suppression, *, title: str) -> discord.Embed:
+def build_suppression_embed(suppression: Suppression, *, title: str) -> discord.Embed:
     """Build a detailed embed for one suppression."""
     embed = discord.Embed(
         title=title,
@@ -546,7 +546,7 @@ def _build_suppression_embed(suppression: Suppression, *, title: str) -> discord
     return embed
 
 
-def _build_suppression_list_embeds(package_name: str, suppressions: list[Suppression]) -> list[discord.Embed]:
+def build_suppression_list_embeds(package_name: str, suppressions: list[Suppression]) -> list[discord.Embed]:
     """Build bounded summary embeds for every suppression against a package."""
     if not suppressions:
         return [
@@ -586,7 +586,7 @@ async def _send_suppression_list(
     suppressions: list[Suppression],
 ) -> None:
     """Send each bounded suppression list page as an ephemeral embed."""
-    for embed in _build_suppression_list_embeds(package_name, suppressions):
+    for embed in build_suppression_list_embeds(package_name, suppressions):
         await interaction.followup.send(embed=embed, ephemeral=True)
 
 
@@ -625,7 +625,7 @@ class SuppressionCommandGroup(discord.app_commands.Group):
 
     async def on_error(
         self: Self,
-        interaction: discord.Interaction[Bot],
+        interaction: discord.Interaction[discord.Client],
         error: discord.app_commands.AppCommandError,
     ) -> None:
         """Return an actionable ephemeral response for suppression command failures."""
@@ -973,7 +973,7 @@ class Dragonfly(commands.Cog):
             parsed_id,
         )
         await interaction.followup.send(
-            embed=_build_suppression_embed(suppression, title="Suppression details"),
+            embed=build_suppression_embed(suppression, title="Suppression details"),
             ephemeral=True,
         )
 
@@ -1005,7 +1005,7 @@ class Dragonfly(commands.Cog):
             parsed_rules,
         )
         await interaction.followup.send(
-            embed=_build_suppression_embed(suppression, title="Suppression created"),
+            embed=build_suppression_embed(suppression, title="Suppression created"),
             ephemeral=True,
         )
 
@@ -1044,7 +1044,7 @@ class Dragonfly(commands.Cog):
             parsed_rules,
         )
         await interaction.followup.send(
-            embed=_build_suppression_embed(suppression, title="Suppression updated"),
+            embed=build_suppression_embed(suppression, title="Suppression updated"),
             ephemeral=True,
         )
 

--- a/src/bot/exts/sandbox.py
+++ b/src/bot/exts/sandbox.py
@@ -1,0 +1,97 @@
+"""Queue packages for analysis by snakehook-runner."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from json import JSONDecodeError
+from typing import cast
+
+import aiohttp
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from bot.bot import Bot
+from bot.constants import Roles
+from bot.constants import Sandbox as SandboxConfig
+
+log = logging.getLogger(__name__)
+
+SANDBOX_TRIAGE_URL = "https://sandbox.vipyrsec.com/v1/triage"
+SANDBOX_ERROR_MESSAGES = {
+    HTTPStatus.UNAUTHORIZED: "Sandbox authentication is misconfigured.",
+    HTTPStatus.UNPROCESSABLE_ENTITY: "The package name or version is invalid.",
+    HTTPStatus.TOO_MANY_REQUESTS: "Sandbox policy or rate limits rejected this request.",
+    HTTPStatus.SERVICE_UNAVAILABLE: "The sandbox queue is currently full. Please try again later.",
+}
+SANDBOX_UNAVAILABLE_MESSAGE = "Sandbox analysis is temporarily unavailable."
+
+
+class Sandbox(commands.Cog):
+    """Snakehook sandbox commands."""
+
+    def __init__(self, bot: Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(name="sandbox", description="Queue a Python package for sandbox analysis")
+    @app_commands.describe(name="PyPI package name", version="Exact package version")
+    @app_commands.checks.has_role(Roles.vipyr_security)  # type: ignore[arg-type]
+    async def sandbox_command(
+        self,
+        interaction: discord.Interaction[Bot],
+        name: str,
+        version: str,
+    ) -> None:
+        """Queue an exact package release for sandbox analysis."""
+        await interaction.response.defer(thinking=True, ephemeral=True)
+
+        api_key = SandboxConfig.api_key.get_secret_value()
+        if not api_key:
+            log.error("SANDBOX_API_KEY is not configured")
+            await interaction.followup.send(SANDBOX_UNAVAILABLE_MESSAGE, ephemeral=True)
+            return
+
+        try:
+            async with self.bot.http_session.post(
+                SANDBOX_TRIAGE_URL,
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"package_name": name, "version": version},
+            ) as response:
+                if response.status != HTTPStatus.ACCEPTED:
+                    message = SANDBOX_ERROR_MESSAGES.get(
+                        HTTPStatus(response.status),
+                        SANDBOX_UNAVAILABLE_MESSAGE,
+                    )
+                    log.warning("Sandbox rejected a queue request with HTTP %d", response.status)
+                    await interaction.followup.send(message, ephemeral=True)
+                    return
+
+                run_id = _read_run_id(await response.json())
+        except (TimeoutError, aiohttp.ClientError, JSONDecodeError, ValueError):
+            log.warning("Sandbox queue request failed", exc_info=True)
+            await interaction.followup.send(SANDBOX_UNAVAILABLE_MESSAGE, ephemeral=True)
+            return
+
+        if run_id is None:
+            log.error("Sandbox accepted a request without returning a run ID")
+            await interaction.followup.send(SANDBOX_UNAVAILABLE_MESSAGE, ephemeral=True)
+            return
+
+        await interaction.followup.send(
+            f"Queued `{name} v{version}` for sandbox analysis. Run ID: `{run_id}`",
+            ephemeral=True,
+        )
+
+
+def _read_run_id(payload: object) -> str | None:
+    """Extract a non-empty run ID from a sandbox response."""
+    if not isinstance(payload, dict):
+        return None
+    run_id = cast("dict[object, object]", payload).get("run_id")
+    return run_id if isinstance(run_id, str) and run_id else None
+
+
+async def setup(bot: Bot) -> None:
+    """Load the sandbox cog."""
+    await bot.add_cog(Sandbox(bot))

--- a/src/bot/exts/sandbox.py
+++ b/src/bot/exts/sandbox.py
@@ -79,9 +79,17 @@ class Sandbox(commands.Cog):
             return
 
         await interaction.followup.send(
-            f"Queued `{name} v{version}` for sandbox analysis. Run ID: `{run_id}`",
+            f"Queued {_inline_code(f'{name} v{version}')} for sandbox analysis. Run ID: {_inline_code(run_id)}",
             ephemeral=True,
         )
+
+
+def _inline_code(value: str, *, limit: int = 300) -> str:
+    """Format bounded text as inline code without allowing delimiter injection."""
+    escaped = value.replace("`", "'")
+    if len(escaped) > limit:
+        escaped = escaped[: limit - 1] + "…"
+    return f"`{escaped}`"
 
 
 def _read_run_id(payload: object) -> str | None:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,171 @@
+"""Tests for the snakehook sandbox command."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from http import HTTPStatus
+from typing import Any, Self, cast
+from unittest.mock import AsyncMock, Mock, patch
+
+import aiohttp
+import discord
+import pytest
+from discord import app_commands
+from pydantic import SecretStr
+
+from bot.bot import Bot
+from bot.exts import sandbox
+
+
+class _MockResponse:
+    def __init__(self, status: HTTPStatus, payload: object = None) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    async def json(self) -> object:
+        return self._payload
+
+
+def _invoke_command(
+    *,
+    api_key: str = "test-api-key",
+    response: _MockResponse | None = None,
+    request_error: Exception | None = None,
+) -> tuple[Mock, Mock]:
+    session = Mock()
+    if request_error is not None:
+        session.post.side_effect = request_error
+    else:
+        session.post.return_value = response or _MockResponse(
+            HTTPStatus.ACCEPTED,
+            {"run_id": "test-run-id"},
+        )
+
+    bot = cast("Bot", Mock(http_session=session))
+    interaction_mock = Mock()
+    interaction_mock.response.defer = AsyncMock()
+    interaction_mock.followup.send = AsyncMock()
+    interaction = cast("discord.Interaction[Bot]", interaction_mock)
+    cog = sandbox.Sandbox(bot)
+    command = cast("app_commands.Command[Any, ..., Any]", sandbox.Sandbox.sandbox_command)
+    callback = cast(
+        "Callable[[sandbox.Sandbox, discord.Interaction[Bot], str, str], Coroutine[Any, Any, None]]",
+        command.callback,
+    )
+
+    with patch.object(sandbox.SandboxConfig, "api_key", SecretStr(api_key)):
+        asyncio.run(callback(cog, interaction, "example-package", "1.2.3"))
+
+    interaction_mock.response.defer.assert_awaited_once_with(thinking=True, ephemeral=True)
+    return interaction_mock, session
+
+
+def test_sandbox_is_a_role_restricted_slash_command() -> None:
+    """The sandbox queue must be an application command with a role check."""
+    command = sandbox.Sandbox.sandbox_command
+
+    assert isinstance(command, app_commands.Command)
+    assert command.name == "sandbox"
+    assert command.description == "Queue a Python package for sandbox analysis"
+    assert command.checks
+
+
+def test_sandbox_api_key_loads_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SANDBOX_API_KEY must populate a redacting runtime secret."""
+    monkeypatch.setenv("SANDBOX_API_KEY", "configured-api-key")
+
+    config = type(sandbox.SandboxConfig)()
+
+    assert config.api_key.get_secret_value() == "configured-api-key"
+    assert "configured-api-key" not in repr(config)
+
+
+def test_sandbox_command_queues_package() -> None:
+    """An accepted package returns its run ID without exposing the API key."""
+    interaction, session = _invoke_command()
+
+    session.post.assert_called_once_with(
+        sandbox.SANDBOX_TRIAGE_URL,
+        headers={"Authorization": "Bearer test-api-key"},
+        json={"package_name": "example-package", "version": "1.2.3"},
+    )
+    interaction.followup.send.assert_awaited_once_with(
+        "Queued `example-package v1.2.3` for sandbox analysis. Run ID: `test-run-id`",
+        ephemeral=True,
+    )
+
+
+def test_sandbox_command_fails_closed_without_api_key() -> None:
+    """A missing runtime secret must not issue an unauthenticated request."""
+    interaction, session = _invoke_command(api_key="")
+
+    session.post.assert_not_called()
+    interaction.followup.send.assert_awaited_once_with(
+        sandbox.SANDBOX_UNAVAILABLE_MESSAGE,
+        ephemeral=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [
+        (HTTPStatus.UNAUTHORIZED, "Sandbox authentication is misconfigured."),
+        (HTTPStatus.UNPROCESSABLE_ENTITY, "The package name or version is invalid."),
+        (HTTPStatus.TOO_MANY_REQUESTS, "Sandbox policy or rate limits rejected this request."),
+        (HTTPStatus.SERVICE_UNAVAILABLE, "The sandbox queue is currently full. Please try again later."),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, sandbox.SANDBOX_UNAVAILABLE_MESSAGE),
+    ],
+)
+def test_sandbox_command_maps_rejected_requests(status: HTTPStatus, message: str) -> None:
+    """Expected API failures must produce concise, secret-free responses."""
+    interaction, _ = _invoke_command(response=_MockResponse(status))
+
+    interaction.followup.send.assert_awaited_once_with(message, ephemeral=True)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"run_id": ""},
+        {"run_id": 123},
+    ],
+)
+def test_sandbox_command_rejects_invalid_accepted_response(payload: object) -> None:
+    """An accepted response still requires a non-empty string run ID."""
+    interaction, _ = _invoke_command(response=_MockResponse(HTTPStatus.ACCEPTED, payload))
+
+    interaction.followup.send.assert_awaited_once_with(
+        sandbox.SANDBOX_UNAVAILABLE_MESSAGE,
+        ephemeral=True,
+    )
+
+
+def test_sandbox_command_handles_client_failure() -> None:
+    """Network failures must produce a generic response without leaking request details."""
+    interaction, _ = _invoke_command(request_error=aiohttp.ClientConnectionError())
+
+    interaction.followup.send.assert_awaited_once_with(
+        sandbox.SANDBOX_UNAVAILABLE_MESSAGE,
+        ephemeral=True,
+    )
+
+
+def test_sandbox_setup_adds_cog() -> None:
+    """The extension setup must register the sandbox cog."""
+    bot = cast("Bot", Mock())
+    bot.add_cog = AsyncMock()
+
+    asyncio.run(sandbox.setup(bot))
+
+    bot.add_cog.assert_awaited_once()
+    assert bot.add_cog.await_args is not None
+    assert isinstance(bot.add_cog.await_args.args[0], sandbox.Sandbox)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -38,6 +38,8 @@ def _invoke_command(
     api_key: str = "test-api-key",
     response: _MockResponse | None = None,
     request_error: Exception | None = None,
+    name: str = "example-package",
+    version: str = "1.2.3",
 ) -> tuple[Mock, Mock]:
     session = Mock()
     if request_error is not None:
@@ -61,7 +63,7 @@ def _invoke_command(
     )
 
     with patch.object(sandbox.SandboxConfig, "api_key", SecretStr(api_key)):
-        asyncio.run(callback(cog, interaction, "example-package", "1.2.3"))
+        asyncio.run(callback(cog, interaction, name, version))
 
     interaction_mock.response.defer.assert_awaited_once_with(thinking=True, ephemeral=True)
     return interaction_mock, session
@@ -98,6 +100,32 @@ def test_sandbox_command_queues_package() -> None:
     )
     interaction.followup.send.assert_awaited_once_with(
         "Queued `example-package v1.2.3` for sandbox analysis. Run ID: `test-run-id`",
+        ephemeral=True,
+    )
+
+
+def test_sandbox_command_escapes_inline_code_values() -> None:
+    """Package and service text must not inject Discord inline-code delimiters."""
+    interaction, _ = _invoke_command(
+        name="example`package",
+        version="1.`2.3",
+        response=_MockResponse(HTTPStatus.ACCEPTED, {"run_id": "run`id"}),
+    )
+
+    interaction.followup.send.assert_awaited_once_with(
+        "Queued `example'package v1.'2.3` for sandbox analysis. Run ID: `run'id`",
+        ephemeral=True,
+    )
+
+
+def test_inline_code_bounds_response_values() -> None:
+    """Unexpectedly large service values must remain within a Discord response."""
+    interaction, _ = _invoke_command(
+        response=_MockResponse(HTTPStatus.ACCEPTED, {"run_id": "x" * 301}),
+    )
+
+    interaction.followup.send.assert_awaited_once_with(
+        f"Queued `example-package v1.2.3` for sandbox analysis. Run ID: `{'x' * 299}…`",
         ephemeral=True,
     )
 

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -150,11 +150,11 @@ def test_suppression_embeds_bound_large_rule_corpora_and_lists() -> None:
     rules = [f"false_positive_rule_{index:02d}" for index in range(30)]
     suppressions = [suppression(version=f"1.0.{index}", rules=rules) for index in range(11)]
 
-    details = dragonfly._build_suppression_embed(  # noqa: SLF001
+    details = dragonfly.build_suppression_embed(
         suppressions[0],
         title="Suppression details",
     )
-    pages = dragonfly._build_suppression_list_embeds("example-package", suppressions)  # noqa: SLF001
+    pages = dragonfly.build_suppression_list_embeds("example-package", suppressions)
 
     assert details.title == "Suppression details"
     assert details.fields[0].value == "30 selected rules"
@@ -173,7 +173,7 @@ def test_suppression_list_pages_stay_within_aggregate_embed_limit() -> None:
         for index in range(9)
     ]
 
-    pages = dragonfly._build_suppression_list_embeds("p" * 500, suppressions)  # noqa: SLF001
+    pages = dragonfly.build_suppression_list_embeds("p" * 500, suppressions)
 
     assert [len(page.fields) for page in pages] == [8, 1]
     assert all(len(page) <= 6000 for page in pages)


### PR DESCRIPTION
## What changed

- add the role-restricted `/sandbox name:<package> version:<version>` application command
- submit exact package releases to `https://sandbox.vipyrsec.com/v1/triage`
- load `SANDBOX_API_KEY` as a redacting Pydantic runtime secret
- return the accepted run ID and concise messages for authentication, validation,
  policy, capacity, and availability failures
- make the Make lint recipe fail immediately when Pyright fails
- resolve the four strict typing errors that the previous recipe masked

## Why

Vipyr Security operators need a simple Discord path to queue packages in the
snakehook sandbox. The bearer credential must remain runtime-only and must not
appear in source, build arguments, logs, or Discord responses.

While validating the command, the existing Make recipe was found to return
Ruff's status after Pyright failed, causing CI to report success with type
errors. The fail-fast correction makes the required validation meaningful.

## Validation

- `make lint`
  - Pyright: zero errors
  - Ruff: passed
- `make test` (92 passed)
- sandbox module coverage: 100%
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
  - formatting and linting
  - Dockerfile lint
  - GitHub workflow validation
  - schema and YAML validation
  - secret scanning
  - typo checking
