### PR TITLE
Bound Discord alert rule descriptions

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -405,8 +405,8 @@ def _format_scan_rules(rules: list[str]) -> str:
     included: list[str] = []
     for rule in rules:
         candidate = ", ".join((*included, rule))
-        omitted = len(rules) - len(included) - 1
-        truncation_notice = f", … (+{omitted} more)" if omitted else ""
+        omitted_if_excluded = len(rules) - len(included)
+        truncation_notice = f", … (+{omitted_if_excluded} more)"
         if len(candidate) + len(truncation_notice) > content_limit:
             break
         included.append(rule)

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -35,6 +35,9 @@ SUPPRESSION_SERVICE_ERRORS = (
     UnicodeDecodeError,
     ValidationError,
 )
+EMBED_DESCRIPTION_LIMIT = 4096
+RULES_DESCRIPTION_PREFIX = "```YARA rules matched: "
+RULES_DESCRIPTION_SUFFIX = "```"
 
 
 def _build_modal_title(name: str, version: str) -> str:
@@ -370,7 +373,7 @@ def _build_package_scan_result_embed(
 
     embed = discord.Embed(
         title=f"{title} package found: {scan_result.name} @ {scan_result.version}",
-        description=f"```YARA rules matched: {', '.join(scan_result.rules) or 'None'}```",
+        description=_format_scan_rules(scan_result.rules),
         color=color,
         timestamp=scan_result.queued_at,
     )
@@ -391,6 +394,32 @@ def _build_package_scan_result_embed(
     )
 
     return embed
+
+
+def _format_scan_rules(rules: list[str]) -> str:
+    """Format matched rules without exceeding Discord's embed description limit."""
+    if not rules:
+        return f"{RULES_DESCRIPTION_PREFIX}None{RULES_DESCRIPTION_SUFFIX}"
+
+    content_limit = EMBED_DESCRIPTION_LIMIT - len(RULES_DESCRIPTION_PREFIX) - len(RULES_DESCRIPTION_SUFFIX)
+    included: list[str] = []
+    for rule in rules:
+        candidate = ", ".join((*included, rule))
+        omitted = len(rules) - len(included) - 1
+        truncation_notice = f", … (+{omitted} more)" if omitted else ""
+        if len(candidate) + len(truncation_notice) > content_limit:
+            break
+        included.append(rule)
+
+    omitted = len(rules) - len(included)
+    if not included:
+        content = f"… ({omitted} rules omitted)"
+    else:
+        content = ", ".join(included)
+        if omitted:
+            content += f", … (+{omitted} more)"
+
+    return f"{RULES_DESCRIPTION_PREFIX}{content}{RULES_DESCRIPTION_SUFFIX}"
 
 
 def _build_all_packages_scanned_embed(scan_results: list[Package]) -> discord.Embed:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -377,6 +377,35 @@ def test_run_delivers_alert_when_suppressions_are_unavailable() -> None:
     logs_channel_mock.send.assert_awaited_once()
 
 
+def test_scan_iteration_advances_cursor_with_large_rule_set() -> None:
+    bot = cast("Bot", Mock())
+    configure_alerting_api(bot)
+    result = package_result(rules=[f"suspicious_rule_{index:03d}_{'x' * 100}" for index in range(100)])
+    bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
+    bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[])
+    cog = dragonfly.Dragonfly(bot)
+    previous_cursor = cog.since
+    logs_channel_mock = Mock()
+    logs_channel_mock.send = AsyncMock()
+    logs_channel = cast("discord.abc.Messageable", logs_channel_mock)
+
+    async def reject_oversized_alert(*_args: object, **kwargs: object) -> None:
+        embed = cast("discord.Embed", kwargs["embed"])
+        assert embed.description is not None
+        assert len(embed.description) <= dragonfly.EMBED_DESCRIPTION_LIMIT
+
+    alerts_channel_mock = Mock()
+    alerts_channel_mock.send = AsyncMock(side_effect=reject_oversized_alert)
+    alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
+
+    with patch.object(dragonfly, "AlertView", return_value=Mock()):
+        asyncio.run(cog.run_scan_iteration(logs_channel=logs_channel, alerts_channel=alerts_channel))
+
+    assert cog.since > previous_cursor
+    alerts_channel_mock.send.assert_awaited_once()
+    logs_channel_mock.send.assert_awaited_once()
+
+
 def test_inactivity_threshold_is_inclusive() -> None:
     """The configured boundary must trigger exactly when it is reached."""
     now = datetime.now(tz=UTC)

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -377,10 +377,27 @@ def test_run_delivers_alert_when_suppressions_are_unavailable() -> None:
     logs_channel_mock.send.assert_awaited_once()
 
 
-def test_scan_iteration_advances_cursor_with_large_rule_set() -> None:
+@pytest.mark.parametrize(
+    "rules",
+    [
+        [f"suspicious_rule_{index:03d}_{'x' * 100}" for index in range(100)],
+        [
+            "x"
+            * (
+                dragonfly.EMBED_DESCRIPTION_LIMIT
+                - len(dragonfly.RULES_DESCRIPTION_PREFIX)
+                - len(dragonfly.RULES_DESCRIPTION_SUFFIX)
+                - len(", … (+10 more)")
+            ),
+            *[f"omitted_rule_{index}" for index in range(10)],
+        ],
+    ],
+    ids=["many-rules", "omission-digit-boundary"],
+)
+def test_scan_iteration_advances_cursor_with_large_rule_set(rules: list[str]) -> None:
     bot = cast("Bot", Mock())
     configure_alerting_api(bot)
-    result = package_result(rules=[f"suspicious_rule_{index:03d}_{'x' * 100}" for index in range(100)])
+    result = package_result(rules=rules)
     bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
     bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[])
     cog = dragonfly.Dragonfly(bot)


### PR DESCRIPTION
## Summary

- cap Dragonfly alert rule descriptions at Discord's 4,096-character limit
- preserve complete rule names and report how many were omitted
- cover the alert delivery and cursor advancement regression

## Root cause

Packages with sufficiently many matched YARA rules produced an invalid Discord embed. The scan loop posted earlier alerts from the batch, failed on the oversized alert, and never advanced its in-memory `since` cursor. The next iteration therefore replayed the earlier alerts and failed on the same package again.

This was observed in both staging and production as:

```text
discord.errors.HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embeds.0.description: Must be 4096 or fewer in length.
```

## Validation

- `uv run pytest -q` (96 passed)
- scoped `ty check` on the changed source and test
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
