### PR TITLE
Publish OpenGrep shadow evidence

### DIFF
--- a/src/bot/constants.py
+++ b/src/bot/constants.py
@@ -8,7 +8,7 @@ An `.env` file is used to populate env vars, if present.
 from os import getenv
 from typing import ClassVar
 
-from pydantic import SecretStr, field_validator
+from pydantic import SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -78,8 +78,17 @@ class _DragonflyConfig(EnvConfig, env_prefix="dragonfly_"):
     interval: int = 60
     timeout: int = 25
     inactivity_threshold: int = 60 * 10  # 10 minutes
+    opengrep_shadow_enabled: bool = False
 
     reporter_url: str = ""
+
+    @model_validator(mode="after")
+    def restrict_opengrep_shadow_to_staging(self) -> "_DragonflyConfig":
+        """Reject shadow polling against any non-staging API."""
+        if self.opengrep_shadow_enabled and self.api_url.rstrip("/") != "https://dragonfly-staging.vipyrsec.com":
+            msg = "OpenGrep shadow requires the staging Dragonfly API URL"
+            raise ValueError(msg)
+        return self
 
 
 DragonflyConfig = _DragonflyConfig()

--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -205,8 +205,16 @@ class DragonflyServices:
 
     async def get_opengrep_results(self: Self) -> list[OpenGrepResult]:
         """Get completed, unpublished OpenGrep shadow results."""
-        data = await self.make_request("GET", "/opengrep/results")
+        data = await self.make_request("GET", "/opengrep/results", params={"limit": 1})
         return [OpenGrepResult.model_validate(item) for item in data]
+
+    async def heartbeat_opengrep_publication(self: Self, result: OpenGrepResult) -> None:
+        """Renew a publication lease while a Discord operation is in flight."""
+        await self.make_request(
+            "POST",
+            f"/opengrep/results/{result.scan_id}/heartbeat",
+            json={"publication_id": str(result.publication_id)},
+        )
 
     async def checkpoint_opengrep_publication(
         self: Self,

--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -95,6 +95,10 @@ class OpenGrepResult(BaseModel):
     findings: list[OpenGrepFinding]
     fail_reason: str | None
     finished_at: datetime
+    publication_id: uuid.UUID
+    discord_message_id: int | None
+    discord_thread_id: int | None
+    published_chunks: int
 
 
 class Suppression(BaseModel):
@@ -204,11 +208,32 @@ class DragonflyServices:
         data = await self.make_request("GET", "/opengrep/results")
         return [OpenGrepResult.model_validate(item) for item in data]
 
-    async def acknowledge_opengrep_result(self: Self, scan_id: uuid.UUID) -> None:
+    async def checkpoint_opengrep_publication(
+        self: Self,
+        result: OpenGrepResult,
+        *,
+        discord_message_id: int | None,
+        discord_thread_id: int | None,
+        published_chunks: int,
+    ) -> None:
+        """Persist monotonic Discord publication progress."""
+        await self.make_request(
+            "POST",
+            f"/opengrep/results/{result.scan_id}/publication",
+            json={
+                "publication_id": str(result.publication_id),
+                "discord_message_id": discord_message_id,
+                "discord_thread_id": discord_thread_id,
+                "published_chunks": published_chunks,
+            },
+        )
+
+    async def acknowledge_opengrep_result(self: Self, result: OpenGrepResult) -> None:
         """Acknowledge a result after its complete Discord publication."""
         await self.make_request(
             "POST",
-            f"/opengrep/results/{scan_id}/published",
+            f"/opengrep/results/{result.scan_id}/published",
+            json={"publication_id": str(result.publication_id)},
         )
 
     async def update_alerting_configuration(

--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -68,6 +68,35 @@ class AlertingConfiguration(BaseModel):
     updated_by: str
 
 
+class OpenGrepFinding(BaseModel):
+    """One source-level OpenGrep evidence record."""
+
+    rule_id: str
+    path: str
+    start_line: int
+    end_line: int
+    message: str
+    severity: str
+    evidence: str
+    confidence: str
+    execution_context: str
+    inspector_url: str
+
+
+class OpenGrepResult(BaseModel):
+    """A completed OpenGrep shadow result awaiting publication."""
+
+    scan_id: uuid.UUID
+    name: str
+    version: str
+    status: ScanStatus
+    commit: str | None
+    duration_ms: int | None
+    findings: list[OpenGrepFinding]
+    fail_reason: str | None
+    finished_at: datetime
+
+
 class Suppression(BaseModel):
     """A package-version alert suppression owned by Mainframe."""
 
@@ -169,6 +198,18 @@ class DragonflyServices:
         """Get Mainframe's durable production alerting configuration."""
         data = await self.make_request("GET", "/alerting/configuration")
         return AlertingConfiguration.model_validate(data)
+
+    async def get_opengrep_results(self: Self) -> list[OpenGrepResult]:
+        """Get completed, unpublished OpenGrep shadow results."""
+        data = await self.make_request("GET", "/opengrep/results")
+        return [OpenGrepResult.model_validate(item) for item in data]
+
+    async def acknowledge_opengrep_result(self: Self, scan_id: uuid.UUID) -> None:
+        """Acknowledge a result after its complete Discord publication."""
+        await self.make_request(
+            "POST",
+            f"/opengrep/results/{scan_id}/published",
+        )
 
     async def update_alerting_configuration(
         self: Self,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -46,7 +46,6 @@ SUPPRESSION_SERVICE_ERRORS = (
 EMBED_DESCRIPTION_LIMIT = 4096
 RULES_DESCRIPTION_PREFIX = "```YARA rules matched: "
 RULES_DESCRIPTION_SUFFIX = "```"
-DISCORD_MESSAGE_LIMIT = 2000
 OPENGREP_THREAD_CHUNK_LIMIT = 1900
 
 
@@ -485,11 +484,11 @@ def _format_opengrep_finding(finding: OpenGrepFinding) -> str:
         f"{_safe_discord_text(finding.confidence)} / "
         f"{_safe_discord_text(finding.execution_context)}\n"
     )
-    available = OPENGREP_THREAD_CHUNK_LIMIT - len(header)
     message = _safe_discord_text(finding.message)
-    if len(message) > available:
-        message = message[: max(0, available - 1)] + "…"
-    return header + message
+    rendered = header + message
+    if len(rendered) > OPENGREP_THREAD_CHUNK_LIMIT:
+        rendered = rendered[: OPENGREP_THREAD_CHUNK_LIMIT - 1] + "…"
+    return rendered
 
 
 def build_opengrep_thread_chunks(findings: list[OpenGrepFinding]) -> list[str]:
@@ -534,20 +533,76 @@ def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
 
 async def publish_opengrep_result(
     bot: Bot,
-    channel: discord.abc.Messageable,
+    channel: discord.TextChannel,
     result: OpenGrepResult,
 ) -> None:
-    """Publish a summary and complete evidence thread before acknowledging."""
-    message = await channel.send(embed=build_opengrep_summary_embed(result))
-    if result.findings:
-        thread = await message.create_thread(
-            name=f"OpenGrep · {result.name} {result.version}"[:100],
-            auto_archive_duration=1440,
+    """Resume a checkpointed evidence thread and acknowledge it when complete."""
+    message_id = result.discord_message_id
+    thread_id = result.discord_thread_id
+    published_chunks = result.published_chunks
+    if message_id is None:
+        message = await channel.send(embed=build_opengrep_summary_embed(result))
+        message_id = message.id
+        await bot.dragonfly_services.checkpoint_opengrep_publication(
+            result,
+            discord_message_id=message_id,
+            discord_thread_id=thread_id,
+            published_chunks=published_chunks,
         )
-        for chunk in build_opengrep_thread_chunks(result.findings):
-            assert len(chunk) <= DISCORD_MESSAGE_LIMIT
+    else:
+        message = await channel.fetch_message(message_id)
+
+    if result.findings:
+        chunks = build_opengrep_thread_chunks(result.findings)
+        if published_chunks > len(chunks):
+            msg = "Stored OpenGrep publication progress exceeds its evidence chunks"
+            raise RuntimeError(msg)
+        if thread_id is None:
+            thread = await message.create_thread(
+                name=f"OpenGrep · {result.name} {result.version}"[:100],
+                auto_archive_duration=1440,
+            )
+            thread_id = thread.id
+            await bot.dragonfly_services.checkpoint_opengrep_publication(
+                result,
+                discord_message_id=message_id,
+                discord_thread_id=thread_id,
+                published_chunks=published_chunks,
+            )
+        else:
+            thread = bot.get_channel(thread_id)
+            if thread is None:
+                thread = await bot.fetch_channel(thread_id)
+            if not isinstance(thread, discord.Thread):
+                msg = "Stored OpenGrep publication channel is not a Discord thread"
+                raise TypeError(msg)
+        for index, chunk in enumerate(chunks[published_chunks:], start=published_chunks + 1):
             await thread.send(chunk)
-    await bot.dragonfly_services.acknowledge_opengrep_result(result.scan_id)
+            published_chunks = index
+            await bot.dragonfly_services.checkpoint_opengrep_publication(
+                result,
+                discord_message_id=message_id,
+                discord_thread_id=thread_id,
+                published_chunks=published_chunks,
+            )
+    await bot.dragonfly_services.acknowledge_opengrep_result(result)
+
+
+async def publish_opengrep_results(
+    bot: Bot,
+    channel: discord.TextChannel,
+    results: list[OpenGrepResult],
+) -> None:
+    """Publish every claimed result without one failure blocking its batch."""
+    for result in results:
+        try:
+            await publish_opengrep_result(bot, channel, result)
+        except Exception as error:
+            log.exception(
+                "OpenGrep shadow publication failed; the claimed result will resume after its lease expires.",
+                extra={"scan_id": str(result.scan_id)},
+            )
+            sentry_sdk.capture_exception(error)
 
 
 def inactivity_threshold_reached(
@@ -862,14 +917,14 @@ class Dragonfly(commands.Cog):
     async def opengrep_shadow_loop(self: Self) -> None:
         """Publish OpenGrep evidence independently from canonical alerts."""
         channel = self.bot.get_channel(DragonflyConfig.logs_channel_id)
-        assert isinstance(channel, discord.abc.Messageable)
+        assert isinstance(channel, discord.TextChannel)
         try:
             results = await self.bot.dragonfly_services.get_opengrep_results()
-            for result in results:
-                await publish_opengrep_result(self.bot, channel, result)
         except Exception as error:
-            log.exception("OpenGrep shadow publication failed; unacknowledged results will retry.")
+            log.exception("OpenGrep shadow result polling failed.")
             sentry_sdk.capture_exception(error)
+            return
+        await publish_opengrep_results(self.bot, channel, results)
 
     async def run_scan_iteration(
         self,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -21,7 +21,15 @@ from pydantic import ValidationError
 from bot import constants
 from bot.bot import Bot
 from bot.constants import Channels, Colours, DragonflyConfig, Roles
-from bot.dragonfly_services import DragonflyServices, Package, PackageReport, Suppression
+from bot.dragonfly_services import (
+    DragonflyServices,
+    OpenGrepFinding,
+    OpenGrepResult,
+    Package,
+    PackageReport,
+    ScanStatus,
+    Suppression,
+)
 from bot.queue_status import build_queue_status_embed
 from bot.utils.pastebin import PasteFile, PasteRequest, PasteResponse, paste
 
@@ -38,6 +46,8 @@ SUPPRESSION_SERVICE_ERRORS = (
 EMBED_DESCRIPTION_LIMIT = 4096
 RULES_DESCRIPTION_PREFIX = "```YARA rules matched: "
 RULES_DESCRIPTION_SUFFIX = "```"
+DISCORD_MESSAGE_LIMIT = 2000
+OPENGREP_THREAD_CHUNK_LIMIT = 1900
 
 
 def _build_modal_title(name: str, version: str) -> str:
@@ -461,6 +471,85 @@ def _build_scan_error_embed() -> discord.Embed:
     )
 
 
+def _safe_discord_text(value: str) -> str:
+    """Prevent external finding text from creating mentions or code spans."""
+    return value.replace("@", "@\u200b").replace("`", "'")
+
+
+def _format_opengrep_finding(finding: OpenGrepFinding) -> str:
+    """Format one bounded OpenGrep finding for a thread message."""
+    location = f"{_safe_discord_text(finding.path)}:{finding.start_line}-{finding.end_line}"
+    header = (
+        f"**{_safe_discord_text(finding.rule_id)}** · `{location}`\n"
+        f"{_safe_discord_text(finding.evidence)} / "
+        f"{_safe_discord_text(finding.confidence)} / "
+        f"{_safe_discord_text(finding.execution_context)}\n"
+    )
+    available = OPENGREP_THREAD_CHUNK_LIMIT - len(header)
+    message = _safe_discord_text(finding.message)
+    if len(message) > available:
+        message = message[: max(0, available - 1)] + "…"
+    return header + message
+
+
+def build_opengrep_thread_chunks(findings: list[OpenGrepFinding]) -> list[str]:
+    """Pack findings into Discord messages without losing finding boundaries."""
+    chunks: list[str] = []
+    current = ""
+    for finding in findings:
+        rendered = _format_opengrep_finding(finding)
+        candidate = f"{current}\n\n{rendered}" if current else rendered
+        if len(candidate) <= OPENGREP_THREAD_CHUNK_LIMIT:
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+        current = rendered
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
+    """Build a compact, explicitly non-verdict OpenGrep summary."""
+    failed = result.status is ScanStatus.FAILED
+    embed = discord.Embed(
+        title=f"OpenGrep shadow: {result.name} @ {result.version}"[:256],
+        description=(
+            "Staging evaluation evidence only; this is not a production verdict."
+            if not failed
+            else f"Shadow scan failed: {_safe_discord_text(result.fail_reason or 'unknown failure')}"
+        ),
+        color=discord.Color.red() if failed else discord.Color.blue(),
+        timestamp=result.finished_at,
+    )
+    embed.add_field(name="Findings", value=str(len(result.findings)), inline=True)
+    duration = "unknown" if result.duration_ms is None else f"{result.duration_ms} ms"
+    embed.add_field(name="Duration", value=duration, inline=True)
+    if result.commit:
+        embed.add_field(name="Rules commit", value=f"`{result.commit[:40]}`", inline=False)
+    embed.set_footer(text=f"OpenGrep shadow scan {result.scan_id}")
+    return embed
+
+
+async def publish_opengrep_result(
+    bot: Bot,
+    channel: discord.abc.Messageable,
+    result: OpenGrepResult,
+) -> None:
+    """Publish a summary and complete evidence thread before acknowledging."""
+    message = await channel.send(embed=build_opengrep_summary_embed(result))
+    if result.findings:
+        thread = await message.create_thread(
+            name=f"OpenGrep · {result.name} {result.version}"[:100],
+            auto_archive_duration=1440,
+        )
+        for chunk in build_opengrep_thread_chunks(result.findings):
+            assert len(chunk) <= DISCORD_MESSAGE_LIMIT
+            await thread.send(chunk)
+    await bot.dragonfly_services.acknowledge_opengrep_result(result.scan_id)
+
+
 def inactivity_threshold_reached(
     *,
     now: datetime,
@@ -769,6 +858,19 @@ class Dragonfly(commands.Cog):
         except Exception as error:  # noqa: BLE001 - A monitoring loop must survive unexpected failures.
             await self.handle_scan_error(error, alerts_channel)
 
+    @tasks.loop(seconds=DragonflyConfig.interval)
+    async def opengrep_shadow_loop(self: Self) -> None:
+        """Publish OpenGrep evidence independently from canonical alerts."""
+        channel = self.bot.get_channel(DragonflyConfig.logs_channel_id)
+        assert isinstance(channel, discord.abc.Messageable)
+        try:
+            results = await self.bot.dragonfly_services.get_opengrep_results()
+            for result in results:
+                await publish_opengrep_result(self.bot, channel, result)
+        except Exception as error:
+            log.exception("OpenGrep shadow publication failed; unacknowledged results will retry.")
+            sentry_sdk.capture_exception(error)
+
     async def run_scan_iteration(
         self,
         *,
@@ -842,6 +944,11 @@ class Dragonfly(commands.Cog):
 
     @scan_loop.before_loop
     async def before_scan_loop(self: Self) -> None:
+        """Wait until the bot is ready."""
+        await self.bot.wait_until_ready()
+
+    @opengrep_shadow_loop.before_loop
+    async def before_opengrep_shadow_loop(self: Self) -> None:
         """Wait until the bot is ready."""
         await self.bot.wait_until_ready()
 
@@ -1158,4 +1265,6 @@ async def setup(bot: Bot) -> None:
     task = cog.scan_loop
     if not task.is_running():
         task.start()
+    if DragonflyConfig.opengrep_shadow_enabled and not cog.opengrep_shadow_loop.is_running():
+        cog.opengrep_shadow_loop.start()
     await bot.add_cog(cog)

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import urllib.parse
 import uuid
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from json import JSONDecodeError
@@ -47,6 +50,7 @@ EMBED_DESCRIPTION_LIMIT = 4096
 RULES_DESCRIPTION_PREFIX = "```YARA rules matched: "
 RULES_DESCRIPTION_SUFFIX = "```"
 OPENGREP_THREAD_CHUNK_LIMIT = 1900
+OPENGREP_PUBLICATION_HEARTBEAT_SECONDS = 60
 
 
 def _build_modal_title(name: str, version: str) -> str:
@@ -531,6 +535,31 @@ def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
     return embed
 
 
+async def await_discord_with_opengrep_lease[T](
+    bot: Bot,
+    result: OpenGrepResult,
+    operation: Callable[[], Awaitable[T]],
+) -> T:
+    """Keep the publication claim current while awaiting one Discord operation."""
+    await bot.dragonfly_services.heartbeat_opengrep_publication(result)
+    task = asyncio.ensure_future(operation())
+    try:
+        while True:
+            done, _pending = await asyncio.wait(
+                {task},
+                timeout=OPENGREP_PUBLICATION_HEARTBEAT_SECONDS,
+            )
+            if task in done:
+                return await task
+            await bot.dragonfly_services.heartbeat_opengrep_publication(result)
+    except BaseException:
+        if not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        raise
+
+
 async def publish_opengrep_result(
     bot: Bot,
     channel: discord.TextChannel,
@@ -541,7 +570,11 @@ async def publish_opengrep_result(
     thread_id = result.discord_thread_id
     published_chunks = result.published_chunks
     if message_id is None:
-        message = await channel.send(embed=build_opengrep_summary_embed(result))
+        message = await await_discord_with_opengrep_lease(
+            bot,
+            result,
+            lambda: channel.send(embed=build_opengrep_summary_embed(result)),
+        )
         message_id = message.id
         await bot.dragonfly_services.checkpoint_opengrep_publication(
             result,
@@ -550,7 +583,11 @@ async def publish_opengrep_result(
             published_chunks=published_chunks,
         )
     else:
-        message = await channel.fetch_message(message_id)
+        message = await await_discord_with_opengrep_lease(
+            bot,
+            result,
+            lambda: channel.fetch_message(message_id),
+        )
 
     if result.findings:
         chunks = build_opengrep_thread_chunks(result.findings)
@@ -558,9 +595,13 @@ async def publish_opengrep_result(
             msg = "Stored OpenGrep publication progress exceeds its evidence chunks"
             raise RuntimeError(msg)
         if thread_id is None:
-            thread = await message.create_thread(
-                name=f"OpenGrep · {result.name} {result.version}"[:100],
-                auto_archive_duration=1440,
+            thread = await await_discord_with_opengrep_lease(
+                bot,
+                result,
+                lambda: message.create_thread(
+                    name=f"OpenGrep · {result.name} {result.version}"[:100],
+                    auto_archive_duration=1440,
+                ),
             )
             thread_id = thread.id
             await bot.dragonfly_services.checkpoint_opengrep_publication(
@@ -572,12 +613,20 @@ async def publish_opengrep_result(
         else:
             thread = bot.get_channel(thread_id)
             if thread is None:
-                thread = await bot.fetch_channel(thread_id)
+                thread = await await_discord_with_opengrep_lease(
+                    bot,
+                    result,
+                    lambda: bot.fetch_channel(thread_id),
+                )
             if not isinstance(thread, discord.Thread):
                 msg = "Stored OpenGrep publication channel is not a Discord thread"
                 raise TypeError(msg)
         for index, chunk in enumerate(chunks[published_chunks:], start=published_chunks + 1):
-            await thread.send(chunk)
+            await await_discord_with_opengrep_lease(
+                bot,
+                result,
+                lambda chunk=chunk: thread.send(chunk),
+            )
             published_chunks = index
             await bot.dragonfly_services.checkpoint_opengrep_publication(
                 result,

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -522,7 +522,7 @@ def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
             "Staging evaluation evidence only; this is not a production verdict."
             if not failed
             else f"Shadow scan failed: {_safe_discord_text(result.fail_reason or 'unknown failure')}"
-        ),
+        )[:EMBED_DESCRIPTION_LIMIT],
         color=discord.Color.red() if failed else discord.Color.blue(),
         timestamp=result.finished_at,
     )

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import re
 import urllib.parse
@@ -535,6 +536,16 @@ def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
     return embed
 
 
+def opengrep_publication_nonce(
+    scan_id: uuid.UUID,
+    operation: str,
+    index: int = 0,
+) -> str:
+    """Build a stable Discord nonce so retried sends are idempotent."""
+    source = f"{scan_id}:{operation}:{index}".encode()
+    return hashlib.blake2s(source, digest_size=8).hexdigest()
+
+
 async def await_discord_with_opengrep_lease[T](
     bot: Bot,
     result: OpenGrepResult,
@@ -573,7 +584,10 @@ async def publish_opengrep_result(
         message = await await_discord_with_opengrep_lease(
             bot,
             result,
-            lambda: channel.send(embed=build_opengrep_summary_embed(result)),
+            lambda: channel.send(
+                embed=build_opengrep_summary_embed(result),
+                nonce=opengrep_publication_nonce(result.scan_id, "summary"),
+            ),
         )
         message_id = message.id
         await bot.dragonfly_services.checkpoint_opengrep_publication(
@@ -595,14 +609,21 @@ async def publish_opengrep_result(
             msg = "Stored OpenGrep publication progress exceeds its evidence chunks"
             raise RuntimeError(msg)
         if thread_id is None:
-            thread = await await_discord_with_opengrep_lease(
-                bot,
-                result,
-                lambda: message.create_thread(
-                    name=f"OpenGrep · {result.name} {result.version}"[:100],
-                    auto_archive_duration=1440,
-                ),
-            )
+            try:
+                thread = await await_discord_with_opengrep_lease(
+                    bot,
+                    result,
+                    message.fetch_thread,
+                )
+            except discord.NotFound:
+                thread = await await_discord_with_opengrep_lease(
+                    bot,
+                    result,
+                    lambda: message.create_thread(
+                        name=f"OpenGrep · {result.name} {result.version}"[:100],
+                        auto_archive_duration=1440,
+                    ),
+                )
             thread_id = thread.id
             await bot.dragonfly_services.checkpoint_opengrep_publication(
                 result,
@@ -625,7 +646,10 @@ async def publish_opengrep_result(
             await await_discord_with_opengrep_lease(
                 bot,
                 result,
-                lambda chunk=chunk: thread.send(chunk),
+                lambda chunk=chunk, index=index: thread.send(
+                    chunk,
+                    nonce=opengrep_publication_nonce(result.scan_id, "chunk", index),
+                ),
             )
             published_chunks = index
             await bot.dragonfly_services.checkpoint_opengrep_publication(

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -6,13 +6,14 @@ import asyncio
 import datetime as dt
 import uuid
 from typing import Any, Self
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
 from bot.dragonfly_services import (
     AlertingConfiguration,
     DragonflyServices,
+    OpenGrepResult,
     Package,
     PackageReport,
     QueueStatus,
@@ -263,6 +264,51 @@ def test_update_alerting_configuration() -> None:
         "/alerting/configuration",
         json={"production_score_threshold": 12},
     )
+
+
+def test_get_and_acknowledge_opengrep_results() -> None:
+    service = _service()
+    scan_id = uuid.uuid4()
+    finished_at = dt.datetime(2026, 7, 30, 12, 0, tzinfo=dt.UTC)
+    service.make_request = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "scan_id": str(scan_id),
+                    "name": "example",
+                    "version": "1.0.0",
+                    "status": "finished",
+                    "commit": "abc123",
+                    "duration_ms": 42,
+                    "findings": [],
+                    "fail_reason": None,
+                    "finished_at": int(finished_at.timestamp()),
+                }
+            ],
+            {"published_at": int(finished_at.timestamp())},
+        ]
+    )
+
+    results = asyncio.run(service.get_opengrep_results())
+    asyncio.run(service.acknowledge_opengrep_result(scan_id))
+
+    assert results == [
+        OpenGrepResult(
+            scan_id=scan_id,
+            name="example",
+            version="1.0.0",
+            status=ScanStatus.FINISHED,
+            commit="abc123",
+            duration_ms=42,
+            findings=[],
+            fail_reason=None,
+            finished_at=finished_at,
+        )
+    ]
+    assert service.make_request.await_args_list == [
+        call("GET", "/opengrep/results"),
+        call("POST", f"/opengrep/results/{scan_id}/published"),
+    ]
 
 
 def _suppression_payload(

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -291,12 +291,14 @@ def test_get_and_acknowledge_opengrep_results() -> None:
                 }
             ],
             {},
+            {},
             {"published_at": int(finished_at.timestamp())},
         ]
     )
 
     results = asyncio.run(service.get_opengrep_results())
     result = results[0]
+    asyncio.run(service.heartbeat_opengrep_publication(result))
     asyncio.run(
         service.checkpoint_opengrep_publication(
             result,
@@ -325,7 +327,12 @@ def test_get_and_acknowledge_opengrep_results() -> None:
         )
     ]
     assert service.make_request.await_args_list == [
-        call("GET", "/opengrep/results"),
+        call("GET", "/opengrep/results", params={"limit": 1}),
+        call(
+            "POST",
+            f"/opengrep/results/{scan_id}/heartbeat",
+            json={"publication_id": str(publication_id)},
+        ),
         call(
             "POST",
             f"/opengrep/results/{scan_id}/publication",

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -269,6 +269,7 @@ def test_update_alerting_configuration() -> None:
 def test_get_and_acknowledge_opengrep_results() -> None:
     service = _service()
     scan_id = uuid.uuid4()
+    publication_id = uuid.uuid4()
     finished_at = dt.datetime(2026, 7, 30, 12, 0, tzinfo=dt.UTC)
     service.make_request = AsyncMock(
         side_effect=[
@@ -283,14 +284,28 @@ def test_get_and_acknowledge_opengrep_results() -> None:
                     "findings": [],
                     "fail_reason": None,
                     "finished_at": int(finished_at.timestamp()),
+                    "publication_id": str(publication_id),
+                    "discord_message_id": None,
+                    "discord_thread_id": None,
+                    "published_chunks": 0,
                 }
             ],
+            {},
             {"published_at": int(finished_at.timestamp())},
         ]
     )
 
     results = asyncio.run(service.get_opengrep_results())
-    asyncio.run(service.acknowledge_opengrep_result(scan_id))
+    result = results[0]
+    asyncio.run(
+        service.checkpoint_opengrep_publication(
+            result,
+            discord_message_id=100,
+            discord_thread_id=200,
+            published_chunks=1,
+        )
+    )
+    asyncio.run(service.acknowledge_opengrep_result(result))
 
     assert results == [
         OpenGrepResult(
@@ -303,11 +318,29 @@ def test_get_and_acknowledge_opengrep_results() -> None:
             findings=[],
             fail_reason=None,
             finished_at=finished_at,
+            publication_id=publication_id,
+            discord_message_id=None,
+            discord_thread_id=None,
+            published_chunks=0,
         )
     ]
     assert service.make_request.await_args_list == [
         call("GET", "/opengrep/results"),
-        call("POST", f"/opengrep/results/{scan_id}/published"),
+        call(
+            "POST",
+            f"/opengrep/results/{scan_id}/publication",
+            json={
+                "publication_id": str(publication_id),
+                "discord_message_id": 100,
+                "discord_thread_id": 200,
+                "published_chunks": 1,
+            },
+        ),
+        call(
+            "POST",
+            f"/opengrep/results/{scan_id}/published",
+            json={"publication_id": str(publication_id)},
+        ),
     ]
 
 

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -15,7 +15,15 @@ from discord import app_commands
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.dragonfly_services import AlertingConfiguration, Package, ScanStatus, Suppression
+from bot.constants import DragonflyConfig
+from bot.dragonfly_services import (
+    AlertingConfiguration,
+    OpenGrepFinding,
+    OpenGrepResult,
+    Package,
+    ScanStatus,
+    Suppression,
+)
 from bot.exts.dragonfly import dragonfly
 
 
@@ -27,6 +35,22 @@ def configure_alerting_api(bot: Bot, threshold: int = 8) -> None:
             updated_by="test",
         )
     )
+
+
+def test_opengrep_bot_polling_is_staging_only() -> None:
+    config_type = type(DragonflyConfig)
+    with pytest.raises(ValueError, match="staging Dragonfly API URL"):
+        config_type(
+            api_url="https://dragonfly.vipyrsec.com",
+            opengrep_shadow_enabled=True,
+        )
+
+    config = config_type(
+        api_url="https://dragonfly-staging.vipyrsec.com",
+        opengrep_shadow_enabled=True,
+    )
+
+    assert config.opengrep_shadow_enabled
 
 
 def package_result(*, version: str = "1.0.0", rules: list[str] | None = None) -> Package:
@@ -48,6 +72,104 @@ def package_result(*, version: str = "1.0.0", rules: list[str] | None = None) ->
         finished_by="test",
         commit_hash="commit",
     )
+
+
+def opengrep_result(*, findings: list[OpenGrepFinding] | None = None) -> OpenGrepResult:
+    return OpenGrepResult(
+        scan_id=uuid.uuid4(),
+        name="example-package",
+        version="1.0.0",
+        status=ScanStatus.FINISHED,
+        commit="a" * 40,
+        duration_ms=42,
+        findings=findings or [],
+        fail_reason=None,
+        finished_at=datetime.now(tz=UTC),
+    )
+
+
+def opengrep_finding(index: int = 0, *, message: str = "Behavioral evidence.") -> OpenGrepFinding:
+    return OpenGrepFinding(
+        rule_id=f"python-flow-example-{index}",
+        path=f"src/module_{index}.py",
+        start_line=3,
+        end_line=7,
+        message=message,
+        severity="ERROR",
+        evidence="flow",
+        confidence="high",
+        execution_context="import_time_same_file_call",
+        inspector_url=f"https://inspector.example/src/module_{index}.py",
+    )
+
+
+def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
+    findings = [
+        opengrep_finding(
+            index,
+            message=f"evidence @{index} `" + ("x" * 1200),
+        )
+        for index in range(5)
+    ]
+
+    chunks = dragonfly.build_opengrep_thread_chunks(findings)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= dragonfly.OPENGREP_THREAD_CHUNK_LIMIT for chunk in chunks)
+    assert all("@\u200b" in chunk for chunk in chunks)
+    assert all("`x" not in chunk for chunk in chunks)
+
+
+def test_publish_opengrep_result_acks_after_complete_thread() -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    thread = Mock()
+    thread.send = AsyncMock()
+    message = Mock()
+    message.create_thread = AsyncMock(return_value=thread)
+    channel = Mock()
+    channel.send = AsyncMock(return_value=message)
+    result = opengrep_result(findings=[opengrep_finding(index) for index in range(3)])
+
+    asyncio.run(
+        dragonfly.publish_opengrep_result(
+            bot,
+            cast("discord.abc.Messageable", channel),
+            result,
+        )
+    )
+
+    channel.send.assert_awaited_once()
+    summary = channel.send.await_args.kwargs["embed"]
+    assert summary.title == "OpenGrep shadow: example-package @ 1.0.0"
+    assert summary.description is not None
+    assert "not a production verdict" in summary.description
+    message.create_thread.assert_awaited_once()
+    assert thread.send.await_count == 1
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result.scan_id)
+
+
+def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    thread = Mock()
+    thread.send = AsyncMock(side_effect=RuntimeError("Discord unavailable"))
+    message = Mock()
+    message.create_thread = AsyncMock(return_value=thread)
+    channel = Mock()
+    channel.send = AsyncMock(return_value=message)
+    result = opengrep_result(findings=[opengrep_finding()])
+
+    with pytest.raises(RuntimeError, match="Discord unavailable"):
+        asyncio.run(
+            dragonfly.publish_opengrep_result(
+                bot,
+                cast("discord.abc.Messageable", channel),
+                result,
+            )
+        )
+
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_not_awaited()
 
 
 def suppression(*, version: str = "1.0.0", rules: list[str] | None = None) -> Suppression:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -136,6 +136,21 @@ def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
     assert len(rendered[0]) == dragonfly.OPENGREP_THREAD_CHUNK_LIMIT
 
 
+def test_opengrep_failure_summary_is_bounded() -> None:
+    result = opengrep_result().model_copy(
+        update={
+            "status": ScanStatus.FAILED,
+            "fail_reason": "failure @" + ("x" * 5000),
+        }
+    )
+
+    embed = dragonfly.build_opengrep_summary_embed(result)
+
+    assert embed.description is not None
+    assert len(embed.description) == dragonfly.EMBED_DESCRIPTION_LIMIT
+    assert "@\u200b" in embed.description
+
+
 def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     bot = cast("Bot", Mock())
     bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -74,7 +74,13 @@ def package_result(*, version: str = "1.0.0", rules: list[str] | None = None) ->
     )
 
 
-def opengrep_result(*, findings: list[OpenGrepFinding] | None = None) -> OpenGrepResult:
+def opengrep_result(
+    *,
+    findings: list[OpenGrepFinding] | None = None,
+    discord_message_id: int | None = None,
+    discord_thread_id: int | None = None,
+    published_chunks: int = 0,
+) -> OpenGrepResult:
     return OpenGrepResult(
         scan_id=uuid.uuid4(),
         name="example-package",
@@ -85,6 +91,10 @@ def opengrep_result(*, findings: list[OpenGrepFinding] | None = None) -> OpenGre
         findings=findings or [],
         fail_reason=None,
         finished_at=datetime.now(tz=UTC),
+        publication_id=uuid.uuid4(),
+        discord_message_id=discord_message_id,
+        discord_thread_id=discord_thread_id,
+        published_chunks=published_chunks,
     )
 
 
@@ -119,13 +129,22 @@ def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
     assert all("@\u200b" in chunk for chunk in chunks)
     assert all("`x" not in chunk for chunk in chunks)
 
+    oversized_header = opengrep_finding()
+    oversized_header.path = "p" * 5000
+    rendered = dragonfly.build_opengrep_thread_chunks([oversized_header])
+    assert len(rendered) == 1
+    assert len(rendered[0]) == dragonfly.OPENGREP_THREAD_CHUNK_LIMIT
+
 
 def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     bot = cast("Bot", Mock())
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
     bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
-    thread = Mock()
+    thread = Mock(spec=discord.Thread)
+    thread.id = 200
     thread.send = AsyncMock()
     message = Mock()
+    message.id = 100
     message.create_thread = AsyncMock(return_value=thread)
     channel = Mock()
     channel.send = AsyncMock(return_value=message)
@@ -134,7 +153,7 @@ def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     asyncio.run(
         dragonfly.publish_opengrep_result(
             bot,
-            cast("discord.abc.Messageable", channel),
+            cast("discord.TextChannel", channel),
             result,
         )
     )
@@ -146,15 +165,19 @@ def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     assert "not a production verdict" in summary.description
     message.create_thread.assert_awaited_once()
     assert thread.send.await_count == 1
-    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result.scan_id)
+    assert bot.dragonfly_services.checkpoint_opengrep_publication.await_count == 3
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
 
 
 def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
     bot = cast("Bot", Mock())
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
     bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
-    thread = Mock()
+    thread = Mock(spec=discord.Thread)
+    thread.id = 200
     thread.send = AsyncMock(side_effect=RuntimeError("Discord unavailable"))
     message = Mock()
+    message.id = 100
     message.create_thread = AsyncMock(return_value=thread)
     channel = Mock()
     channel.send = AsyncMock(return_value=message)
@@ -164,12 +187,63 @@ def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
         asyncio.run(
             dragonfly.publish_opengrep_result(
                 bot,
-                cast("discord.abc.Messageable", channel),
+                cast("discord.TextChannel", channel),
                 result,
             )
         )
 
     bot.dragonfly_services.acknowledge_opengrep_result.assert_not_awaited()
+
+
+def test_publish_opengrep_result_resumes_recorded_thread_progress() -> None:
+    bot_mock = Mock()
+    bot = cast("Bot", bot_mock)
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    thread = Mock(spec=discord.Thread)
+    thread.send = AsyncMock()
+    bot_mock.get_channel.return_value = thread
+    channel = Mock()
+    channel.fetch_message = AsyncMock()
+    channel.send = AsyncMock()
+    result = opengrep_result(
+        findings=[opengrep_finding(index) for index in range(3)],
+        discord_message_id=100,
+        discord_thread_id=200,
+        published_chunks=1,
+    )
+
+    asyncio.run(
+        dragonfly.publish_opengrep_result(
+            bot,
+            cast("discord.TextChannel", channel),
+            result,
+        )
+    )
+
+    channel.send.assert_not_awaited()
+    channel.fetch_message.assert_awaited_once_with(100)
+    assert thread.send.await_count == 0
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
+
+
+def test_publish_opengrep_results_isolates_each_result_failure() -> None:
+    bot = cast("Bot", Mock())
+    channel = cast("discord.TextChannel", Mock())
+    results = [opengrep_result(), opengrep_result()]
+
+    with (
+        patch.object(
+            dragonfly,
+            "publish_opengrep_result",
+            AsyncMock(side_effect=[RuntimeError("first failed"), None]),
+        ) as publish,
+        patch.object(dragonfly.sentry_sdk, "capture_exception") as capture_exception,
+    ):
+        asyncio.run(dragonfly.publish_opengrep_results(bot, channel, results))
+
+    assert publish.await_count == 2
+    capture_exception.assert_called_once()
 
 
 def suppression(*, version: str = "1.0.0", rules: list[str] | None = None) -> Suppression:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -138,6 +138,7 @@ def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
 
 def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     bot = cast("Bot", Mock())
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
     bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
     bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
     thread = Mock(spec=discord.Thread)
@@ -165,12 +166,14 @@ def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     assert "not a production verdict" in summary.description
     message.create_thread.assert_awaited_once()
     assert thread.send.await_count == 1
+    assert bot.dragonfly_services.heartbeat_opengrep_publication.await_count == 3
     assert bot.dragonfly_services.checkpoint_opengrep_publication.await_count == 3
     bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
 
 
 def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
     bot = cast("Bot", Mock())
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
     bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
     bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
     thread = Mock(spec=discord.Thread)
@@ -198,6 +201,7 @@ def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
 def test_publish_opengrep_result_resumes_recorded_thread_progress() -> None:
     bot_mock = Mock()
     bot = cast("Bot", bot_mock)
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
     bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
     bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
     thread = Mock(spec=discord.Thread)
@@ -225,6 +229,34 @@ def test_publish_opengrep_result_resumes_recorded_thread_progress() -> None:
     channel.fetch_message.assert_awaited_once_with(100)
     assert thread.send.await_count == 0
     bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
+
+
+def test_discord_operation_renews_opengrep_lease_while_waiting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
+    result = opengrep_result()
+    completed = False
+
+    async def slow_operation() -> str:
+        nonlocal completed
+        await asyncio.sleep(0.01)
+        completed = True
+        return "complete"
+
+    monkeypatch.setattr(dragonfly, "OPENGREP_PUBLICATION_HEARTBEAT_SECONDS", 0.001)
+    response = asyncio.run(
+        dragonfly.await_discord_with_opengrep_lease(
+            bot,
+            result,
+            slow_operation,
+        )
+    )
+
+    assert response == "complete"
+    assert completed
+    assert bot.dragonfly_services.heartbeat_opengrep_publication.await_count > 1
 
 
 def test_publish_opengrep_results_isolates_each_result_failure() -> None:

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -113,6 +113,11 @@ def opengrep_finding(index: int = 0, *, message: str = "Behavioral evidence.") -
     )
 
 
+def discord_not_found() -> discord.NotFound:
+    response = Mock(status=404, reason="Not Found")
+    return discord.NotFound(response, "Unknown Channel")
+
+
 def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
     findings = [
         opengrep_finding(
@@ -161,6 +166,7 @@ def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     thread.send = AsyncMock()
     message = Mock()
     message.id = 100
+    message.fetch_thread = AsyncMock(side_effect=discord_not_found())
     message.create_thread = AsyncMock(return_value=thread)
     channel = Mock()
     channel.send = AsyncMock(return_value=message)
@@ -181,7 +187,7 @@ def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     assert "not a production verdict" in summary.description
     message.create_thread.assert_awaited_once()
     assert thread.send.await_count == 1
-    assert bot.dragonfly_services.heartbeat_opengrep_publication.await_count == 3
+    assert bot.dragonfly_services.heartbeat_opengrep_publication.await_count == 4
     assert bot.dragonfly_services.checkpoint_opengrep_publication.await_count == 3
     bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
 
@@ -196,6 +202,7 @@ def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
     thread.send = AsyncMock(side_effect=RuntimeError("Discord unavailable"))
     message = Mock()
     message.id = 100
+    message.fetch_thread = AsyncMock(side_effect=discord_not_found())
     message.create_thread = AsyncMock(return_value=thread)
     channel = Mock()
     channel.send = AsyncMock(return_value=message)
@@ -211,6 +218,76 @@ def test_publish_opengrep_result_does_not_ack_partial_thread() -> None:
         )
 
     bot.dragonfly_services.acknowledge_opengrep_result.assert_not_awaited()
+
+
+def test_publish_opengrep_retry_uses_stable_summary_nonce() -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock(
+        side_effect=[RuntimeError("checkpoint unavailable"), None]
+    )
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    message = Mock(id=100)
+    channel = Mock()
+    channel.send = AsyncMock(return_value=message)
+    result = opengrep_result()
+
+    with pytest.raises(RuntimeError, match="checkpoint unavailable"):
+        asyncio.run(
+            dragonfly.publish_opengrep_result(
+                bot,
+                cast("discord.TextChannel", channel),
+                result,
+            )
+        )
+    asyncio.run(
+        dragonfly.publish_opengrep_result(
+            bot,
+            cast("discord.TextChannel", channel),
+            result,
+        )
+    )
+
+    first_nonce = channel.send.await_args_list[0].kwargs["nonce"]
+    second_nonce = channel.send.await_args_list[1].kwargs["nonce"]
+    assert first_nonce == second_nonce
+    assert first_nonce == dragonfly.opengrep_publication_nonce(result.scan_id, "summary")
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
+
+
+def test_publish_opengrep_retry_recovers_existing_thread() -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    thread = Mock(spec=discord.Thread)
+    thread.id = 100
+    thread.send = AsyncMock()
+    message = Mock()
+    message.fetch_thread = AsyncMock(return_value=thread)
+    message.create_thread = AsyncMock()
+    channel = Mock()
+    channel.fetch_message = AsyncMock(return_value=message)
+    result = opengrep_result(
+        findings=[opengrep_finding()],
+        discord_message_id=100,
+    )
+
+    asyncio.run(
+        dragonfly.publish_opengrep_result(
+            bot,
+            cast("discord.TextChannel", channel),
+            result,
+        )
+    )
+
+    message.fetch_thread.assert_awaited_once()
+    message.create_thread.assert_not_awaited()
+    assert thread.send.await_args.kwargs["nonce"] == dragonfly.opengrep_publication_nonce(
+        result.scan_id,
+        "chunk",
+        1,
+    )
 
 
 def test_publish_opengrep_result_resumes_recorded_thread_progress() -> None:


### PR DESCRIPTION
## Summary

- poll completed OpenGrep results in a separate staging-gated task
- publish a non-verdict summary and bounded Discord evidence thread
- neutralize mentions and acknowledge only after the complete thread is sent
- leave the existing YARA alert loop and role mentions unchanged

## Validation

- `ruff`, `pyright`, and complete `prek` suite
- 101 pytest tests, including partial-thread retry behavior and staging fences
