### PR TITLE
Queue OpenGrep after delivered alerts

### DIFF
--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -208,6 +208,14 @@ class DragonflyServices:
         data = await self.make_request("GET", "/opengrep/results", params={"limit": 1})
         return [OpenGrepResult.model_validate(item) for item in data]
 
+    async def queue_opengrep_alert(self: Self, package: Package) -> None:
+        """Queue staging shadow work for a package after its alert is delivered."""
+        await self.make_request(
+            "POST",
+            "/opengrep/alerts",
+            json={"name": package.name, "version": package.version},
+        )
+
     async def heartbeat_opengrep_publication(self: Self, result: OpenGrepResult) -> None:
         """Renew a publication lease while a Discord operation is in flight."""
         await self.make_request(

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -930,6 +930,16 @@ async def run(
             embed=embed,
             view=AlertView(bot, result),
         )
+        if DragonflyConfig.opengrep_shadow_enabled:
+            try:
+                await bot.dragonfly_services.queue_opengrep_alert(result)
+            except Exception as error:
+                log.exception(
+                    "Failed to queue OpenGrep shadow work for alerting package %s@%s.",
+                    result.name,
+                    result.version,
+                )
+                sentry_sdk.capture_exception(error)
 
     all_packages_scanned_embed = _build_all_packages_scanned_embed(scan_results)
     if len(all_packages_scanned_embed) <= 4096:  # noqa: PLR2004

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -152,6 +152,36 @@ def test_get_scanned_packages() -> None:
     )
 
 
+def test_queue_opengrep_alert() -> None:
+    service = _service()
+    service.make_request = AsyncMock()
+    package = Package(
+        scan_id="scan-id",
+        name="example",
+        version="1.0.0",
+        status=ScanStatus.FINISHED,
+        score=10,
+        inspector_url=None,
+        queued_at=None,
+        queued_by=None,
+        reported_at=None,
+        reported_by=None,
+        pending_at=None,
+        pending_by=None,
+        finished_at=None,
+        finished_by=None,
+        commit_hash=None,
+    )
+
+    asyncio.run(service.queue_opengrep_alert(package))
+
+    service.make_request.assert_awaited_once_with(
+        "POST",
+        "/opengrep/alerts",
+        json={"name": "example", "version": "1.0.0"},
+    )
+
+
 def test_report_package() -> None:
     service = _service()
     service.make_request = AsyncMock()

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -642,11 +642,15 @@ def test_alert_suppress_button_preserves_empty_rule_corpus() -> None:
     )
 
 
-def test_run_omits_suppressed_alert_but_keeps_scan_log() -> None:
+def test_run_omits_suppressed_alert_and_opengrep_work_but_keeps_scan_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     bot = cast("Bot", Mock())
     result = package_result(rules=["false_positive"])
     bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
     bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[suppression(rules=["false_positive"])])
+    bot.dragonfly_services.queue_opengrep_alert = AsyncMock()
+    monkeypatch.setattr(dragonfly.DragonflyConfig, "opengrep_shadow_enabled", True)
     alerts_channel_mock = Mock()
     alerts_channel_mock.send = AsyncMock()
     alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
@@ -666,6 +670,7 @@ def test_run_omits_suppressed_alert_but_keeps_scan_log() -> None:
 
     assert scan_results == [result]
     bot.dragonfly_services.get_suppressions.assert_awaited_once_with("Example_Package")
+    bot.dragonfly_services.queue_opengrep_alert.assert_not_awaited()
     alerts_channel_mock.send.assert_not_awaited()
     logs_channel_mock.send.assert_awaited_once()
 
@@ -693,6 +698,68 @@ def test_run_delivers_alert_when_suppressions_are_unavailable() -> None:
             )
         )
 
+    alerts_channel_mock.send.assert_awaited_once()
+    logs_channel_mock.send.assert_awaited_once()
+
+
+def test_run_queues_opengrep_only_after_alert_delivery(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=["suspicious"])
+    bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
+    bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[])
+    alerts_channel_mock = Mock()
+    alerts_channel_mock.send = AsyncMock()
+    alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
+    logs_channel_mock = Mock()
+    logs_channel_mock.send = AsyncMock()
+    logs_channel = cast("discord.abc.Messageable", logs_channel_mock)
+
+    async def assert_alert_was_delivered(_result: Package) -> None:
+        alerts_channel_mock.send.assert_awaited_once()
+
+    bot.dragonfly_services.queue_opengrep_alert = AsyncMock(side_effect=assert_alert_was_delivered)
+    monkeypatch.setattr(dragonfly.DragonflyConfig, "opengrep_shadow_enabled", True)
+
+    with patch.object(dragonfly, "AlertView", return_value=Mock()):
+        asyncio.run(
+            dragonfly.run(
+                bot,
+                since=datetime.now(tz=UTC),
+                alerts_channel=alerts_channel,
+                logs_channel=logs_channel,
+                score=8,
+            )
+        )
+
+    bot.dragonfly_services.queue_opengrep_alert.assert_awaited_once_with(result)
+
+
+def test_opengrep_queue_failure_does_not_interrupt_alerts(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = cast("Bot", Mock())
+    result = package_result(rules=["suspicious"])
+    bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
+    bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[])
+    bot.dragonfly_services.queue_opengrep_alert = AsyncMock(side_effect=RuntimeError("shadow unavailable"))
+    alerts_channel_mock = Mock()
+    alerts_channel_mock.send = AsyncMock()
+    alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
+    logs_channel_mock = Mock()
+    logs_channel_mock.send = AsyncMock()
+    logs_channel = cast("discord.abc.Messageable", logs_channel_mock)
+    monkeypatch.setattr(dragonfly.DragonflyConfig, "opengrep_shadow_enabled", True)
+
+    with patch.object(dragonfly, "AlertView", return_value=Mock()):
+        scan_results = asyncio.run(
+            dragonfly.run(
+                bot,
+                since=datetime.now(tz=UTC),
+                alerts_channel=alerts_channel,
+                logs_channel=logs_channel,
+                score=8,
+            )
+        )
+
+    assert scan_results == [result]
     alerts_channel_mock.send.assert_awaited_once()
     logs_channel_mock.send.assert_awaited_once()
 


### PR DESCRIPTION
## Summary

- notify Mainframe only after an unsuppressed YARA alert is successfully sent
- keep OpenGrep handoff failures isolated from the canonical alert loop
- cover delivered-alert ordering, suppressed packages, and failure isolation

## Safety properties

- clean, below-threshold, suppressed, and failed-to-deliver packages never
  create OpenGrep work
- production remains disabled by the existing staging-only startup guard
- OpenGrep failures cannot prevent canonical alerts or scan-log publication
- no credential, tenant, audience, account, or token value is added

## Validation

- 110 tests passed
- focused alert/service suite: 52 tests passed
- `ruff format --check .`
- `ruff check .`
- full `prek-workspace run --all-files`, including `ripsecrets`
