### PR TITLE
Aggregate OpenGrep alert thread replies

### DIFF
--- a/src/bot/dragonfly_services.py
+++ b/src/bot/dragonfly_services.py
@@ -96,6 +96,7 @@ class OpenGrepResult(BaseModel):
     fail_reason: str | None
     finished_at: datetime
     publication_id: uuid.UUID
+    discord_alert_message_id: int | None = None
     discord_message_id: int | None
     discord_thread_id: int | None
     published_chunks: int
@@ -208,12 +209,16 @@ class DragonflyServices:
         data = await self.make_request("GET", "/opengrep/results", params={"limit": 1})
         return [OpenGrepResult.model_validate(item) for item in data]
 
-    async def queue_opengrep_alert(self: Self, package: Package) -> None:
+    async def queue_opengrep_alert(self: Self, package: Package, discord_alert_message_id: int) -> None:
         """Queue staging shadow work for a package after its alert is delivered."""
         await self.make_request(
             "POST",
             "/opengrep/alerts",
-            json={"name": package.name, "version": package.version},
+            json={
+                "name": package.name,
+                "version": package.version,
+                "discord_alert_message_id": discord_alert_message_id,
+            },
         )
 
     async def heartbeat_opengrep_publication(self: Self, result: OpenGrepResult) -> None:

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -480,28 +480,64 @@ def _safe_discord_text(value: str) -> str:
     return value.replace("@", "@\u200b").replace("`", "'")
 
 
-def _format_opengrep_finding(finding: OpenGrepFinding) -> str:
-    """Format one bounded OpenGrep finding for a thread message."""
-    location = f"{_safe_discord_text(finding.path)}:{finding.start_line}-{finding.end_line}"
+def _format_opengrep_group(findings: list[OpenGrepFinding]) -> str:
+    """Aggregate equivalent findings into one bounded rule block."""
+    finding = findings[0]
+    locations = list(
+        dict.fromkeys(f"{_safe_discord_text(item.path)}:{item.start_line}-{item.end_line}" for item in findings)
+    )
+    match_label = "match" if len(findings) == 1 else "matches"
     header = (
-        f"**{_safe_discord_text(finding.rule_id)}** · `{location}`\n"
+        f"**{_safe_discord_text(finding.rule_id)}** · {len(findings)} {match_label}\n"
         f"{_safe_discord_text(finding.evidence)} / "
         f"{_safe_discord_text(finding.confidence)} / "
         f"{_safe_discord_text(finding.execution_context)}\n"
     )
-    message = _safe_discord_text(finding.message)
-    rendered = header + message
-    if len(rendered) > OPENGREP_THREAD_CHUNK_LIMIT:
-        rendered = rendered[: OPENGREP_THREAD_CHUNK_LIMIT - 1] + "…"
-    return rendered
+    message = _safe_discord_text(finding.message)[:800]
+    prefix = f"{header}{message}\nLocations: "
+    included: list[str] = []
+    for location in locations:
+        omitted = len(locations) - len(included) - 1
+        suffix = f" … (+{omitted} more)" if omitted else ""
+        candidate = ", ".join([*included, location]) + suffix
+        if len(prefix) + len(candidate) > OPENGREP_THREAD_CHUNK_LIMIT:
+            break
+        included.append(location)
+
+    omitted = len(locations) - len(included)
+    location_text = ", ".join(included)
+    if omitted:
+        location_text += f" … (+{omitted} more)"
+    return prefix + location_text
 
 
-def build_opengrep_thread_chunks(findings: list[OpenGrepFinding]) -> list[str]:
-    """Pack findings into Discord messages without losing finding boundaries."""
+def build_opengrep_thread_chunks(result: OpenGrepResult) -> list[str]:
+    """Pack one scan into bounded messages grouped by equivalent findings."""
+    duration = "unknown duration" if result.duration_ms is None else f"{result.duration_ms} ms"
+    header = (
+        f"**OpenGrep shadow** · {len(result.findings)} findings · {duration}\n"
+        "Staging evaluation evidence only; this is not a production verdict."
+    )
+    if result.status is ScanStatus.FAILED:
+        reason = _safe_discord_text(result.fail_reason or "unknown failure")
+        return [f"{header}\nScan failed: {reason}"[:OPENGREP_THREAD_CHUNK_LIMIT]]
+
+    grouped: dict[tuple[str, str, str, str, str, str], list[OpenGrepFinding]] = {}
+    for finding in result.findings:
+        key = (
+            finding.rule_id,
+            finding.message,
+            finding.severity,
+            finding.evidence,
+            finding.confidence,
+            finding.execution_context,
+        )
+        grouped.setdefault(key, []).append(finding)
+
     chunks: list[str] = []
-    current = ""
-    for finding in findings:
-        rendered = _format_opengrep_finding(finding)
+    current = header
+    for findings in grouped.values():
+        rendered = _format_opengrep_group(findings)
         candidate = f"{current}\n\n{rendered}" if current else rendered
         if len(candidate) <= OPENGREP_THREAD_CHUNK_LIMIT:
             current = candidate
@@ -511,7 +547,7 @@ def build_opengrep_thread_chunks(findings: list[OpenGrepFinding]) -> list[str]:
         current = rendered
     if current:
         chunks.append(current)
-    return chunks
+    return chunks or [header]
 
 
 def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
@@ -571,12 +607,12 @@ async def await_discord_with_opengrep_lease[T](
         raise
 
 
-async def publish_opengrep_result(
+async def _publish_legacy_opengrep_result(
     bot: Bot,
     channel: discord.TextChannel,
     result: OpenGrepResult,
 ) -> None:
-    """Resume a checkpointed evidence thread and acknowledge it when complete."""
+    """Publish results queued before alert-thread routing metadata existed."""
     message_id = result.discord_message_id
     thread_id = result.discord_thread_id
     published_chunks = result.published_chunks
@@ -604,7 +640,7 @@ async def publish_opengrep_result(
         )
 
     if result.findings:
-        chunks = build_opengrep_thread_chunks(result.findings)
+        chunks = build_opengrep_thread_chunks(result)
         if published_chunks > len(chunks):
             msg = "Stored OpenGrep publication progress exceeds its evidence chunks"
             raise RuntimeError(msg)
@@ -658,6 +694,78 @@ async def publish_opengrep_result(
                 discord_thread_id=thread_id,
                 published_chunks=published_chunks,
             )
+    await bot.dragonfly_services.acknowledge_opengrep_result(result)
+
+
+async def publish_opengrep_result(
+    bot: Bot,
+    channel: discord.TextChannel,
+    result: OpenGrepResult,
+) -> None:
+    """Reply to the originating package alert and acknowledge when complete."""
+    alert_message_id = result.discord_alert_message_id
+    if alert_message_id is None:
+        await _publish_legacy_opengrep_result(bot, channel, result)
+        return
+
+    thread_id = result.discord_thread_id
+    published_chunks = result.published_chunks
+    alert = await await_discord_with_opengrep_lease(
+        bot,
+        result,
+        lambda: channel.fetch_message(alert_message_id),
+    )
+    if thread_id is None:
+        try:
+            thread = await await_discord_with_opengrep_lease(bot, result, alert.fetch_thread)
+        except discord.NotFound:
+            thread = await await_discord_with_opengrep_lease(
+                bot,
+                result,
+                lambda: alert.create_thread(
+                    name=f"OpenGrep · {result.name} {result.version}"[:100],
+                    auto_archive_duration=1440,
+                ),
+            )
+        thread_id = thread.id
+        await bot.dragonfly_services.checkpoint_opengrep_publication(
+            result,
+            discord_message_id=result.discord_message_id,
+            discord_thread_id=thread_id,
+            published_chunks=published_chunks,
+        )
+    else:
+        thread = bot.get_channel(thread_id)
+        if thread is None:
+            thread = await await_discord_with_opengrep_lease(
+                bot,
+                result,
+                lambda: bot.fetch_channel(thread_id),
+            )
+        if not isinstance(thread, discord.Thread):
+            msg = "Stored OpenGrep publication channel is not a Discord thread"
+            raise TypeError(msg)
+
+    chunks = build_opengrep_thread_chunks(result)
+    if published_chunks > len(chunks):
+        msg = "Stored OpenGrep publication progress exceeds its evidence chunks"
+        raise RuntimeError(msg)
+    for index, chunk in enumerate(chunks[published_chunks:], start=published_chunks + 1):
+        await await_discord_with_opengrep_lease(
+            bot,
+            result,
+            lambda chunk=chunk, index=index: thread.send(
+                chunk,
+                nonce=opengrep_publication_nonce(result.scan_id, "chunk", index),
+            ),
+        )
+        published_chunks = index
+        await bot.dragonfly_services.checkpoint_opengrep_publication(
+            result,
+            discord_message_id=result.discord_message_id,
+            discord_thread_id=thread_id,
+            published_chunks=published_chunks,
+        )
     await bot.dragonfly_services.acknowledge_opengrep_result(result)
 
 
@@ -925,14 +1033,14 @@ async def run(
             result,
             production_score_threshold=score,
         )
-        await alerts_channel.send(
+        alert = await alerts_channel.send(
             f"<@&{DragonflyConfig.alerts_role_id}>",
             embed=embed,
             view=AlertView(bot, result),
         )
         if DragonflyConfig.opengrep_shadow_enabled:
             try:
-                await bot.dragonfly_services.queue_opengrep_alert(result)
+                await bot.dragonfly_services.queue_opengrep_alert(result, alert.id)
             except Exception as error:
                 log.exception(
                     "Failed to queue OpenGrep shadow work for alerting package %s@%s.",
@@ -998,8 +1106,8 @@ class Dragonfly(commands.Cog):
 
     @tasks.loop(seconds=DragonflyConfig.interval)
     async def opengrep_shadow_loop(self: Self) -> None:
-        """Publish OpenGrep evidence independently from canonical alerts."""
-        channel = self.bot.get_channel(DragonflyConfig.logs_channel_id)
+        """Publish OpenGrep evidence in the originating alert threads."""
+        channel = self.bot.get_channel(DragonflyConfig.alerts_channel_id)
         assert isinstance(channel, discord.TextChannel)
         try:
             results = await self.bot.dragonfly_services.get_opengrep_results()

--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -488,10 +488,10 @@ def _format_opengrep_group(findings: list[OpenGrepFinding]) -> str:
     )
     match_label = "match" if len(findings) == 1 else "matches"
     header = (
-        f"**{_safe_discord_text(finding.rule_id)}** · {len(findings)} {match_label}\n"
-        f"{_safe_discord_text(finding.evidence)} / "
-        f"{_safe_discord_text(finding.confidence)} / "
-        f"{_safe_discord_text(finding.execution_context)}\n"
+        f"**{_safe_discord_text(finding.rule_id)[:200]}** · {len(findings)} {match_label}\n"
+        f"{_safe_discord_text(finding.evidence)[:32]} / "
+        f"{_safe_discord_text(finding.confidence)[:20]} / "
+        f"{_safe_discord_text(finding.execution_context)[:64]}\n"
     )
     message = _safe_discord_text(finding.message)[:800]
     prefix = f"{header}{message}\nLocations: "
@@ -715,6 +715,20 @@ async def publish_opengrep_result(
         result,
         lambda: channel.fetch_message(alert_message_id),
     )
+    stored_thread_id = thread_id
+    thread = bot.get_channel(stored_thread_id) if stored_thread_id is not None else None
+    if stored_thread_id is not None:
+        try:
+            if thread is None:
+                thread = await await_discord_with_opengrep_lease(
+                    bot,
+                    result,
+                    lambda: bot.fetch_channel(stored_thread_id),
+                )
+        except discord.NotFound:
+            thread_id = None
+            published_chunks = 0
+
     if thread_id is None:
         try:
             thread = await await_discord_with_opengrep_lease(bot, result, alert.fetch_thread)
@@ -734,17 +748,9 @@ async def publish_opengrep_result(
             discord_thread_id=thread_id,
             published_chunks=published_chunks,
         )
-    else:
-        thread = bot.get_channel(thread_id)
-        if thread is None:
-            thread = await await_discord_with_opengrep_lease(
-                bot,
-                result,
-                lambda: bot.fetch_channel(thread_id),
-            )
-        if not isinstance(thread, discord.Thread):
-            msg = "Stored OpenGrep publication channel is not a Discord thread"
-            raise TypeError(msg)
+    if not isinstance(thread, discord.Thread):
+        msg = "Stored OpenGrep publication channel is not a Discord thread"
+        raise TypeError(msg)
 
     chunks = build_opengrep_thread_chunks(result)
     if published_chunks > len(chunks):

--- a/tests/test_dragonfly_services.py
+++ b/tests/test_dragonfly_services.py
@@ -173,12 +173,16 @@ def test_queue_opengrep_alert() -> None:
         commit_hash=None,
     )
 
-    asyncio.run(service.queue_opengrep_alert(package))
+    asyncio.run(service.queue_opengrep_alert(package, 123))
 
     service.make_request.assert_awaited_once_with(
         "POST",
         "/opengrep/alerts",
-        json={"name": "example", "version": "1.0.0"},
+        json={
+            "name": "example",
+            "version": "1.0.0",
+            "discord_alert_message_id": 123,
+        },
     )
 
 

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -138,6 +138,10 @@ def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
 
     oversized_header = opengrep_finding()
     oversized_header.path = "p" * 5000
+    oversized_header.rule_id = "r" * 5000
+    oversized_header.evidence = "e" * 5000
+    oversized_header.confidence = "c" * 5000
+    oversized_header.execution_context = "x" * 5000
     rendered = dragonfly.build_opengrep_thread_chunks(opengrep_result(findings=[oversized_header]))
     assert len(rendered) == 1
     assert len(rendered[0]) <= dragonfly.OPENGREP_THREAD_CHUNK_LIMIT
@@ -236,6 +240,40 @@ def test_publish_opengrep_result_replies_to_originating_alert_thread() -> None:
     alert.create_thread.assert_awaited_once()
     thread.send.assert_awaited_once()
     assert "2 matches" in thread.send.await_args.args[0]
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
+
+
+def test_publish_opengrep_result_replaces_a_deleted_checkpointed_thread() -> None:
+    bot_mock = Mock()
+    bot = cast("Bot", bot_mock)
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    replacement = Mock(spec=discord.Thread)
+    replacement.id = 300
+    replacement.send = AsyncMock()
+    alert = Mock()
+    alert.fetch_thread = AsyncMock(side_effect=discord_not_found())
+    alert.create_thread = AsyncMock(return_value=replacement)
+    channel = Mock()
+    channel.fetch_message = AsyncMock(return_value=alert)
+    bot_mock.get_channel.return_value = None
+    bot_mock.fetch_channel = AsyncMock(side_effect=discord_not_found())
+    result = opengrep_result(
+        findings=[opengrep_finding()],
+        discord_alert_message_id=123,
+        discord_thread_id=200,
+        published_chunks=1,
+    )
+
+    asyncio.run(dragonfly.publish_opengrep_result(bot, cast("discord.TextChannel", channel), result))
+
+    bot_mock.fetch_channel.assert_awaited_once_with(200)
+    alert.create_thread.assert_awaited_once()
+    first_checkpoint = bot.dragonfly_services.checkpoint_opengrep_publication.await_args_list[0]
+    assert first_checkpoint.kwargs["discord_thread_id"] == 300
+    assert first_checkpoint.kwargs["published_chunks"] == 0
+    replacement.send.assert_awaited_once()
     bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
 
 

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -77,6 +77,7 @@ def package_result(*, version: str = "1.0.0", rules: list[str] | None = None) ->
 def opengrep_result(
     *,
     findings: list[OpenGrepFinding] | None = None,
+    discord_alert_message_id: int | None = None,
     discord_message_id: int | None = None,
     discord_thread_id: int | None = None,
     published_chunks: int = 0,
@@ -92,6 +93,7 @@ def opengrep_result(
         fail_reason=None,
         finished_at=datetime.now(tz=UTC),
         publication_id=uuid.uuid4(),
+        discord_alert_message_id=discord_alert_message_id,
         discord_message_id=discord_message_id,
         discord_thread_id=discord_thread_id,
         published_chunks=published_chunks,
@@ -127,7 +129,7 @@ def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
         for index in range(5)
     ]
 
-    chunks = dragonfly.build_opengrep_thread_chunks(findings)
+    chunks = dragonfly.build_opengrep_thread_chunks(opengrep_result(findings=findings))
 
     assert len(chunks) > 1
     assert all(len(chunk) <= dragonfly.OPENGREP_THREAD_CHUNK_LIMIT for chunk in chunks)
@@ -136,9 +138,23 @@ def test_opengrep_thread_chunks_are_bounded_and_neutralize_mentions() -> None:
 
     oversized_header = opengrep_finding()
     oversized_header.path = "p" * 5000
-    rendered = dragonfly.build_opengrep_thread_chunks([oversized_header])
+    rendered = dragonfly.build_opengrep_thread_chunks(opengrep_result(findings=[oversized_header]))
     assert len(rendered) == 1
-    assert len(rendered[0]) == dragonfly.OPENGREP_THREAD_CHUNK_LIMIT
+    assert len(rendered[0]) <= dragonfly.OPENGREP_THREAD_CHUNK_LIMIT
+    assert "(+1 more)" in rendered[0]
+
+
+def test_opengrep_thread_chunks_aggregate_equivalent_findings() -> None:
+    first = opengrep_finding()
+    second = first.model_copy(update={"path": "src/other.py", "start_line": 9, "end_line": 9})
+
+    chunks = dragonfly.build_opengrep_thread_chunks(opengrep_result(findings=[first, second]))
+
+    rendered = "\n".join(chunks)
+    assert rendered.count("**python-flow-example-0**") == 1
+    assert "2 matches" in rendered
+    assert "src/module_0.py:3-7" in rendered
+    assert "src/other.py:9-9" in rendered
 
 
 def test_opengrep_failure_summary_is_bounded() -> None:
@@ -189,6 +205,37 @@ def test_publish_opengrep_result_acks_after_complete_thread() -> None:
     assert thread.send.await_count == 1
     assert bot.dragonfly_services.heartbeat_opengrep_publication.await_count == 4
     assert bot.dragonfly_services.checkpoint_opengrep_publication.await_count == 3
+    bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
+
+
+def test_publish_opengrep_result_replies_to_originating_alert_thread() -> None:
+    bot = cast("Bot", Mock())
+    bot.dragonfly_services.heartbeat_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.checkpoint_opengrep_publication = AsyncMock()
+    bot.dragonfly_services.acknowledge_opengrep_result = AsyncMock()
+    thread = Mock(spec=discord.Thread)
+    thread.id = 200
+    thread.send = AsyncMock()
+    alert = Mock()
+    alert.fetch_thread = AsyncMock(side_effect=discord_not_found())
+    alert.create_thread = AsyncMock(return_value=thread)
+    channel = Mock()
+    channel.fetch_message = AsyncMock(return_value=alert)
+    channel.send = AsyncMock()
+    first = opengrep_finding()
+    second = first.model_copy(update={"path": "src/other.py"})
+    result = opengrep_result(
+        findings=[first, second],
+        discord_alert_message_id=123,
+    )
+
+    asyncio.run(dragonfly.publish_opengrep_result(bot, cast("discord.TextChannel", channel), result))
+
+    channel.fetch_message.assert_awaited_once_with(123)
+    channel.send.assert_not_awaited()
+    alert.create_thread.assert_awaited_once()
+    thread.send.assert_awaited_once()
+    assert "2 matches" in thread.send.await_args.args[0]
     bot.dragonfly_services.acknowledge_opengrep_result.assert_awaited_once_with(result)
 
 
@@ -368,6 +415,21 @@ def test_publish_opengrep_results_isolates_each_result_failure() -> None:
 
     assert publish.await_count == 2
     capture_exception.assert_called_once()
+
+
+def test_opengrep_loop_publishes_through_alerts_channel() -> None:
+    bot_mock = Mock()
+    bot = cast("Bot", bot_mock)
+    channel = Mock(spec=discord.TextChannel)
+    bot_mock.get_channel.return_value = channel
+    bot.dragonfly_services.get_opengrep_results = AsyncMock(return_value=[])
+    cog = dragonfly.Dragonfly(bot)
+
+    with patch.object(dragonfly, "publish_opengrep_results", AsyncMock()) as publish:
+        asyncio.run(dragonfly.Dragonfly.opengrep_shadow_loop.coro(cog))
+
+    bot_mock.get_channel.assert_called_once_with(DragonflyConfig.alerts_channel_id)
+    publish.assert_awaited_once_with(bot, channel, [])
 
 
 def suppression(*, version: str = "1.0.0", rules: list[str] | None = None) -> Suppression:
@@ -708,14 +770,16 @@ def test_run_queues_opengrep_only_after_alert_delivery(monkeypatch: pytest.Monke
     bot.dragonfly_services.get_scanned_packages = AsyncMock(return_value=[result])
     bot.dragonfly_services.get_suppressions = AsyncMock(return_value=[])
     alerts_channel_mock = Mock()
-    alerts_channel_mock.send = AsyncMock()
+    alert = Mock(id=123)
+    alerts_channel_mock.send = AsyncMock(return_value=alert)
     alerts_channel = cast("discord.abc.Messageable", alerts_channel_mock)
     logs_channel_mock = Mock()
     logs_channel_mock.send = AsyncMock()
     logs_channel = cast("discord.abc.Messageable", logs_channel_mock)
 
-    async def assert_alert_was_delivered(_result: Package) -> None:
+    async def assert_alert_was_delivered(_result: Package, message_id: int) -> None:
         alerts_channel_mock.send.assert_awaited_once()
+        assert message_id == 123
 
     bot.dragonfly_services.queue_opengrep_alert = AsyncMock(side_effect=assert_alert_was_delivered)
     monkeypatch.setattr(dragonfly.DragonflyConfig, "opengrep_shadow_enabled", True)
@@ -731,7 +795,7 @@ def test_run_queues_opengrep_only_after_alert_delivery(monkeypatch: pytest.Monke
             )
         )
 
-    bot.dragonfly_services.queue_opengrep_alert.assert_awaited_once_with(result)
+    bot.dragonfly_services.queue_opengrep_alert.assert_awaited_once_with(result, 123)
 
 
 def test_opengrep_queue_failure_does_not_interrupt_alerts(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- carry the delivered package-alert message ID into OpenGrep shadow work
- publish results inside the originating alert thread in the configured alerts channel
- group equivalent findings by rule and consolidate their locations
- preserve the legacy publication path for mixed-version rollout and rollback

## Impact

Staging OpenGrep evidence no longer creates separate posts in the logs channel,
and repeated matches render as one bounded rule block per package alert.

## Validation

- `pytest` (112 full-suite tests passed; 39 focused alerting tests passed after final routing coverage)
- complete `prek-workspace run --all-files`
