### PR TITLE
Link OpenGrep findings to Inspector lines

### DIFF
--- a/src/bot/exts/dragonfly/dragonfly.py
+++ b/src/bot/exts/dragonfly/dragonfly.py
@@ -480,12 +480,18 @@ def _safe_discord_text(value: str) -> str:
     return value.replace("@", "@\u200b").replace("`", "'")
 
 
+def _format_opengrep_location(finding: OpenGrepFinding) -> str:
+    """Link one bounded source range directly into PyPI Inspector."""
+    label = f"{_safe_discord_text(finding.path)}:{finding.start_line}-{finding.end_line}"
+    label = label.replace("[", "\\[").replace("]", "\\]")
+    inspector_url = urllib.parse.quote(finding.inspector_url, safe=":/%")
+    return f"[{label}]({inspector_url}#line.{finding.start_line}-{finding.end_line})"
+
+
 def _format_opengrep_group(findings: list[OpenGrepFinding]) -> str:
     """Aggregate equivalent findings into one bounded rule block."""
     finding = findings[0]
-    locations = list(
-        dict.fromkeys(f"{_safe_discord_text(item.path)}:{item.start_line}-{item.end_line}" for item in findings)
-    )
+    locations = list(dict.fromkeys(_format_opengrep_location(item) for item in findings))
     match_label = "match" if len(findings) == 1 else "matches"
     header = (
         f"**{_safe_discord_text(finding.rule_id)[:200]}** · {len(findings)} {match_label}\n"
@@ -521,6 +527,9 @@ def build_opengrep_thread_chunks(result: OpenGrepResult) -> list[str]:
     if result.status is ScanStatus.FAILED:
         reason = _safe_discord_text(result.fail_reason or "unknown failure")
         return [f"{header}\nScan failed: {reason}"[:OPENGREP_THREAD_CHUNK_LIMIT]]
+    if result.fail_reason is not None:
+        reason = _safe_discord_text(result.fail_reason)
+        header = f"{header}\nPartial scan: {reason}"[:OPENGREP_THREAD_CHUNK_LIMIT]
 
     grouped: dict[tuple[str, str, str, str, str, str], list[OpenGrepFinding]] = {}
     for finding in result.findings:
@@ -553,14 +562,20 @@ def build_opengrep_thread_chunks(result: OpenGrepResult) -> list[str]:
 def build_opengrep_summary_embed(result: OpenGrepResult) -> discord.Embed:
     """Build a compact, explicitly non-verdict OpenGrep summary."""
     failed = result.status is ScanStatus.FAILED
+    partial = not failed and result.fail_reason is not None
+    if failed:
+        description = f"Shadow scan failed: {_safe_discord_text(result.fail_reason or 'unknown failure')}"
+    elif partial:
+        description = (
+            "Staging evaluation evidence only; partial results were preserved. "
+            f"{_safe_discord_text(result.fail_reason or '')}"
+        )
+    else:
+        description = "Staging evaluation evidence only; this is not a production verdict."
     embed = discord.Embed(
         title=f"OpenGrep shadow: {result.name} @ {result.version}"[:256],
-        description=(
-            "Staging evaluation evidence only; this is not a production verdict."
-            if not failed
-            else f"Shadow scan failed: {_safe_discord_text(result.fail_reason or 'unknown failure')}"
-        )[:EMBED_DESCRIPTION_LIMIT],
-        color=discord.Color.red() if failed else discord.Color.blue(),
+        description=description[:EMBED_DESCRIPTION_LIMIT],
+        color=discord.Color.red() if failed else discord.Color.orange() if partial else discord.Color.blue(),
         timestamp=result.finished_at,
     )
     embed.add_field(name="Findings", value=str(len(result.findings)), inline=True)

--- a/tests/test_scan_alerting.py
+++ b/tests/test_scan_alerting.py
@@ -161,6 +161,45 @@ def test_opengrep_thread_chunks_aggregate_equivalent_findings() -> None:
     assert "src/other.py:9-9" in rendered
 
 
+def test_opengrep_locations_link_to_inspector_source_lines() -> None:
+    finding = opengrep_finding().model_copy(
+        update={
+            "path": ("python_library_ai_agent-0.1.5/examples/search/.mcp-venv/Lib/site-packages/adodbapi/setup.py"),
+            "start_line": 45,
+            "end_line": 63,
+            "inspector_url": (
+                "https://inspector.pypi.io/project/python-library-ai-agent/0.1.5/packages/"
+                "c9/21/ea70f55d4204480caa0767b4d0a1c673cae2af302755bcbe05c18129dbd4/"
+                "python_library_ai_agent-0.1.5.tar.gz/python_library_ai_agent-0.1.5/"
+                "examples/search/.mcp-venv/Lib/site-packages/adodbapi/setup.py"
+            ),
+        }
+    )
+
+    rendered = "\n".join(dragonfly.build_opengrep_thread_chunks(opengrep_result(findings=[finding])))
+
+    assert (
+        "https://inspector.pypi.io/project/python-library-ai-agent/0.1.5/packages/"
+        "c9/21/ea70f55d4204480caa0767b4d0a1c673cae2af302755bcbe05c18129dbd4/"
+        "python_library_ai_agent-0.1.5.tar.gz/python_library_ai_agent-0.1.5/"
+        "examples/search/.mcp-venv/Lib/site-packages/adodbapi/setup.py#line.45-63"
+    ) in rendered
+
+
+def test_opengrep_partial_results_show_findings_and_diagnostic() -> None:
+    result = opengrep_result(findings=[opengrep_finding()]).model_copy(
+        update={"fail_reason": "Rule python-flow-example timed out."}
+    )
+
+    chunks = dragonfly.build_opengrep_thread_chunks(result)
+    summary = dragonfly.build_opengrep_summary_embed(result)
+
+    assert "Partial scan: Rule python-flow-example timed out." in chunks[0]
+    assert "**python-flow-example-0**" in "\n".join(chunks)
+    assert summary.description is not None
+    assert "partial results were preserved" in summary.description
+
+
 def test_opengrep_failure_summary_is_bounded() -> None:
     result = opengrep_result().model_copy(
         update={


### PR DESCRIPTION
## Summary

- render each OpenGrep location as a direct PyPI Inspector source-range link
- keep equivalent findings aggregated and Discord message sizes bounded
- label partial scans while continuing to display their preserved findings

## Compatibility

The bot consumes the existing `inspector_url` and nullable reason fields. Complete and failed scan rendering remains supported, so this can roll back independently.

## Validation

- `ruff check src tests`
- `ruff format --check src tests`
- `pyright`
- `pytest` (116 passed)
- `/home/rem/github/vipyrsec/.tools/bin/prek-workspace run --all-files`
